### PR TITLE
feat: add Tasks API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ This plugin implements the following RingCentral Team Messaging APIs:
 | **Profile** | Get Person, Get Current User, Get Company Info | `ReadAccounts`, `TeamMessaging` |
 | **Attachments** | Upload, Download | `TeamMessaging` |
 | **Favorite Chats** | List, Add, Remove | `TeamMessaging` |
+| **Tasks** | List, Create, Get, Update, Delete, Complete | `TeamMessaging` |
 
 ### Not Yet Implemented
 
 | Category | APIs | Required Scopes |
 |----------|------|-----------------|
 | **Teams** | List, Create, Get, Update, Delete, Join, Leave, Add/Remove Members, Archive/Unarchive | `TeamMessaging` |
-| **Tasks** | List, Create, Get, Update, Delete, Complete | `TeamMessaging` |
 | **Calendar Events** | List, Create, Get, Update, Delete | `TeamMessaging` |
 | **Notes** | List, Create, Get, Update, Delete, Lock, Unlock, Publish | `TeamMessaging`, `Glip` |
 | **Incoming Webhooks** | List, Create, Get, Delete, Activate, Suspend | `TeamMessaging` |

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -240,6 +240,38 @@ describe("Favorite Chats API", () => {
   });
 });
 
+describe("Tasks API", () => {
+  it("listRingCentralTasks should be exported", async () => {
+    const { listRingCentralTasks } = await import("./api.js");
+    expect(typeof listRingCentralTasks).toBe("function");
+  });
+
+  it("createRingCentralTask should be exported", async () => {
+    const { createRingCentralTask } = await import("./api.js");
+    expect(typeof createRingCentralTask).toBe("function");
+  });
+
+  it("getRingCentralTask should be exported", async () => {
+    const { getRingCentralTask } = await import("./api.js");
+    expect(typeof getRingCentralTask).toBe("function");
+  });
+
+  it("updateRingCentralTask should be exported", async () => {
+    const { updateRingCentralTask } = await import("./api.js");
+    expect(typeof updateRingCentralTask).toBe("function");
+  });
+
+  it("deleteRingCentralTask should be exported", async () => {
+    const { deleteRingCentralTask } = await import("./api.js");
+    expect(typeof deleteRingCentralTask).toBe("function");
+  });
+
+  it("completeRingCentralTask should be exported", async () => {
+    const { completeRingCentralTask } = await import("./api.js");
+    expect(typeof completeRingCentralTask).toBe("function");
+  });
+});
+
 describe("probeRingCentral", () => {
   it("should be exported", async () => {
     const { probeRingCentral } = await import("./api.js");

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,31 @@ export type RingCentralConversation = {
   lastModifiedTime?: string;
 };
 
+export type RingCentralTask = {
+  id?: string;
+  chatId?: string;
+  creatorId?: string;
+  subject?: string;
+  assignees?: Array<{ id?: string }>;
+  completenessCondition?: "Simple" | "AllAssignees" | "Percentage";
+  completenessPercentage?: number;
+  startDate?: string;
+  dueDate?: string;
+  color?: "Black" | "Red" | "Orange" | "Yellow" | "Green" | "Blue" | "Purple" | "Magenta";
+  section?: string;
+  description?: string;
+  recurrence?: {
+    schedule?: "None" | "Daily" | "Weekdays" | "Weekly" | "Monthly" | "Yearly";
+    endingCondition?: "None" | "Count" | "Date";
+    endingAfter?: number;
+    endingOn?: string;
+  };
+  attachments?: RingCentralAttachment[];
+  status?: "Pending" | "InProgress" | "Completed";
+  creationTime?: string;
+  lastModifiedTime?: string;
+};
+
 export type RingCentralPost = {
   id?: string;
   groupId?: string;


### PR DESCRIPTION
## Summary
Add support for RingCentral Tasks API with 6 endpoints.

## New APIs
- `listRingCentralTasks()` - List tasks with filtering (assignee, status) and pagination
- `createRingCentralTask()` - Create task with full options (assignees, dates, color, recurrence)
- `getRingCentralTask()` - Get single task by ID
- `updateRingCentralTask()` - Update task properties
- `deleteRingCentralTask()` - Delete task
- `completeRingCentralTask()` - Mark task complete/incomplete

## Changes
- Added `RingCentralTask` type to `src/types.ts`
- Added 6 API functions to `src/api.ts`
- Added 6 tests (108 total passing)
- Updated README documentation

## Testing
- All 108 tests pass
- TypeScript type checking passes

Required scope: `TeamMessaging`