### PR TITLE
feat: add Calendar Events API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ This plugin implements the following RingCentral Team Messaging APIs:
 | **Attachments** | Upload, Download | `TeamMessaging` |
 | **Favorite Chats** | List, Add, Remove | `TeamMessaging` |
 | **Tasks** | List, Create, Get, Update, Delete, Complete | `TeamMessaging` |
+| **Calendar Events** | List, Create, Get, Update, Delete | `TeamMessaging` |
 
 ### Not Yet Implemented
 
 | Category | APIs | Required Scopes |
 |----------|------|-----------------|
 | **Teams** | List, Create, Get, Update, Delete, Join, Leave, Add/Remove Members, Archive/Unarchive | `TeamMessaging` |
-| **Calendar Events** | List, Create, Get, Update, Delete | `TeamMessaging` |
 | **Notes** | List, Create, Get, Update, Delete, Lock, Unlock, Publish | `TeamMessaging`, `Glip` |
 | **Incoming Webhooks** | List, Create, Get, Delete, Activate, Suspend | `TeamMessaging` |
 | **Compliance Exports** | List, Create, Get | `TeamMessaging` (admin) |

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -272,6 +272,33 @@ describe("Tasks API", () => {
   });
 });
 
+describe("Calendar Events API", () => {
+  it("listRingCentralEvents should be exported", async () => {
+    const { listRingCentralEvents } = await import("./api.js");
+    expect(typeof listRingCentralEvents).toBe("function");
+  });
+
+  it("createRingCentralEvent should be exported", async () => {
+    const { createRingCentralEvent } = await import("./api.js");
+    expect(typeof createRingCentralEvent).toBe("function");
+  });
+
+  it("getRingCentralEvent should be exported", async () => {
+    const { getRingCentralEvent } = await import("./api.js");
+    expect(typeof getRingCentralEvent).toBe("function");
+  });
+
+  it("updateRingCentralEvent should be exported", async () => {
+    const { updateRingCentralEvent } = await import("./api.js");
+    expect(typeof updateRingCentralEvent).toBe("function");
+  });
+
+  it("deleteRingCentralEvent should be exported", async () => {
+    const { deleteRingCentralEvent } = await import("./api.js");
+    expect(typeof deleteRingCentralEvent).toBe("function");
+  });
+});
+
 describe("probeRingCentral", () => {
   it("should be exported", async () => {
     const { probeRingCentral } = await import("./api.js");

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,25 @@ export type RingCentralConversation = {
   lastModifiedTime?: string;
 };
 
+export type RingCentralEvent = {
+  id?: string;
+  chatId?: string;
+  creatorId?: string;
+  title?: string;
+  startTime?: string;
+  endTime?: string;
+  allDay?: boolean;
+  recurrence?: "None" | "Day" | "Weekday" | "Week" | "Month" | "Year";
+  endingCondition?: "None" | "Count" | "Date";
+  endingAfter?: number;
+  endingOn?: string;
+  color?: "Black" | "Red" | "Orange" | "Yellow" | "Green" | "Blue" | "Purple" | "Magenta";
+  location?: string;
+  description?: string;
+  creationTime?: string;
+  lastModifiedTime?: string;
+};
+
 export type RingCentralTask = {
   id?: string;
   chatId?: string;


### PR DESCRIPTION
## Summary
Add support for RingCentral Calendar Events API with 5 endpoints.

## New APIs
- `listRingCentralEvents()` - List events with pagination
- `createRingCentralEvent()` - Create event with recurrence, color, location
- `getRingCentralEvent()` - Get single event by ID
- `updateRingCentralEvent()` - Update event properties
- `deleteRingCentralEvent()` - Delete event

## Changes
- Added `RingCentralEvent` type to `src/types.ts`
- Added 5 API functions to `src/api.ts`
- Added 5 tests (113 total passing)
- Updated README documentation

## Testing
All 113 tests pass. TypeScript type checking passes.

Required scope: `TeamMessaging`

**Note:** This branch is based on `feature/tasks-api` (PR #14). Merge that first.