### PR TITLE
feat: add Notes API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ This plugin implements the following RingCentral Team Messaging APIs:
 | **Favorite Chats** | List, Add, Remove | `TeamMessaging` |
 | **Tasks** | List, Create, Get, Update, Delete, Complete | `TeamMessaging` |
 | **Calendar Events** | List, Create, Get, Update, Delete | `TeamMessaging` |
+| **Notes** | List, Create, Get, Update, Delete, Lock, Unlock, Publish | `TeamMessaging`, `Glip` |
 
 ### Not Yet Implemented
 
 | Category | APIs | Required Scopes |
 |----------|------|-----------------|
 | **Teams** | List, Create, Get, Update, Delete, Join, Leave, Add/Remove Members, Archive/Unarchive | `TeamMessaging` |
-| **Notes** | List, Create, Get, Update, Delete, Lock, Unlock, Publish | `TeamMessaging`, `Glip` |
 | **Incoming Webhooks** | List, Create, Get, Delete, Activate, Suspend | `TeamMessaging` |
 | **Compliance Exports** | List, Create, Get | `TeamMessaging` (admin) |
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -299,6 +299,48 @@ describe("Calendar Events API", () => {
   });
 });
 
+describe("Notes API", () => {
+  it("listRingCentralNotes should be exported", async () => {
+    const { listRingCentralNotes } = await import("./api.js");
+    expect(typeof listRingCentralNotes).toBe("function");
+  });
+
+  it("createRingCentralNote should be exported", async () => {
+    const { createRingCentralNote } = await import("./api.js");
+    expect(typeof createRingCentralNote).toBe("function");
+  });
+
+  it("getRingCentralNote should be exported", async () => {
+    const { getRingCentralNote } = await import("./api.js");
+    expect(typeof getRingCentralNote).toBe("function");
+  });
+
+  it("updateRingCentralNote should be exported", async () => {
+    const { updateRingCentralNote } = await import("./api.js");
+    expect(typeof updateRingCentralNote).toBe("function");
+  });
+
+  it("deleteRingCentralNote should be exported", async () => {
+    const { deleteRingCentralNote } = await import("./api.js");
+    expect(typeof deleteRingCentralNote).toBe("function");
+  });
+
+  it("lockRingCentralNote should be exported", async () => {
+    const { lockRingCentralNote } = await import("./api.js");
+    expect(typeof lockRingCentralNote).toBe("function");
+  });
+
+  it("unlockRingCentralNote should be exported", async () => {
+    const { unlockRingCentralNote } = await import("./api.js");
+    expect(typeof unlockRingCentralNote).toBe("function");
+  });
+
+  it("publishRingCentralNote should be exported", async () => {
+    const { publishRingCentralNote } = await import("./api.js");
+    expect(typeof publishRingCentralNote).toBe("function");
+  });
+});
+
 describe("probeRingCentral", () => {
   it("should be exported", async () => {
     const { probeRingCentral } = await import("./api.js");

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,19 @@ export type RingCentralConversation = {
   lastModifiedTime?: string;
 };
 
+export type RingCentralNote = {
+  id?: string;
+  chatId?: string;
+  creatorId?: string;
+  title?: string;
+  body?: string;
+  status?: "Active" | "Draft";
+  lockedBy?: { id?: string };
+  type?: "Note";
+  creationTime?: string;
+  lastModifiedTime?: string;
+};
+
 export type RingCentralEvent = {
   id?: string;
   chatId?: string;


### PR DESCRIPTION
## Summary
Add support for RingCentral Notes API with 8 endpoints.

## New APIs
- `listRingCentralNotes()` - List notes with status filtering and pagination
- `createRingCentralNote()` - Create note with title and body
- `getRingCentralNote()` - Get single note by ID
- `updateRingCentralNote()` - Update note title/body
- `deleteRingCentralNote()` - Delete note
- `lockRingCentralNote()` - Lock note for editing
- `unlockRingCentralNote()` - Unlock note
- `publishRingCentralNote()` - Publish draft note

## Changes
- Added `RingCentralNote` type to `src/types.ts`
- Added 8 API functions to `src/api.ts`
- Added 8 tests (121 total passing)
- Updated README documentation

## Testing
All 121 tests pass. TypeScript type checking passes.

Required scopes: `TeamMessaging`, `Glip`

**Note:** This branch is based on `feature/events-api` (PR #15). Merge that first.