### PR TITLE
feat: add Teams Management API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ This plugin implements the following RingCentral Team Messaging APIs:
 | **Calendar Events** | List, Create, Get, Update, Delete | `TeamMessaging` |
 | **Notes** | List, Create, Get, Update, Delete, Lock, Unlock, Publish | `TeamMessaging`, `Glip` |
 | **Incoming Webhooks** | List, Create, Get, Delete, Activate, Suspend | `TeamMessaging` |
+| **Teams** | List, Create, Get, Update, Delete, Join, Leave, Add/Remove Members, Archive/Unarchive | `TeamMessaging` |
 
 ### Not Yet Implemented
 
 | Category | APIs | Required Scopes |
 |----------|------|-----------------|
-| **Teams** | List, Create, Get, Update, Delete, Join, Leave, Add/Remove Members, Archive/Unarchive | `TeamMessaging` |
 | **Compliance Exports** | List, Create, Get | `TeamMessaging` (admin) |
 
 ## License

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -373,6 +373,63 @@ describe("Incoming Webhooks API", () => {
   });
 });
 
+describe("Teams API", () => {
+  it("listRingCentralTeams should be exported", async () => {
+    const { listRingCentralTeams } = await import("./api.js");
+    expect(typeof listRingCentralTeams).toBe("function");
+  });
+
+  it("createRingCentralTeam should be exported", async () => {
+    const { createRingCentralTeam } = await import("./api.js");
+    expect(typeof createRingCentralTeam).toBe("function");
+  });
+
+  it("getRingCentralTeam should be exported", async () => {
+    const { getRingCentralTeam } = await import("./api.js");
+    expect(typeof getRingCentralTeam).toBe("function");
+  });
+
+  it("updateRingCentralTeam should be exported", async () => {
+    const { updateRingCentralTeam } = await import("./api.js");
+    expect(typeof updateRingCentralTeam).toBe("function");
+  });
+
+  it("deleteRingCentralTeam should be exported", async () => {
+    const { deleteRingCentralTeam } = await import("./api.js");
+    expect(typeof deleteRingCentralTeam).toBe("function");
+  });
+
+  it("joinRingCentralTeam should be exported", async () => {
+    const { joinRingCentralTeam } = await import("./api.js");
+    expect(typeof joinRingCentralTeam).toBe("function");
+  });
+
+  it("leaveRingCentralTeam should be exported", async () => {
+    const { leaveRingCentralTeam } = await import("./api.js");
+    expect(typeof leaveRingCentralTeam).toBe("function");
+  });
+
+  it("addRingCentralTeamMembers should be exported", async () => {
+    const { addRingCentralTeamMembers } = await import("./api.js");
+    expect(typeof addRingCentralTeamMembers).toBe("function");
+  });
+
+  it("removeRingCentralTeamMembers should be exported", async () => {
+    const { removeRingCentralTeamMembers } = await import("./api.js");
+    expect(typeof removeRingCentralTeamMembers).toBe("function");
+  });
+
+  it("archiveRingCentralTeam should be exported", async () => {
+    const { archiveRingCentralTeam } = await import("./api.js");
+    expect(typeof archiveRingCentralTeam).toBe("function");
+  });
+
+  it("unarchiveRingCentralTeam should be exported", async () => {
+    const { unarchiveRingCentralTeam } = await import("./api.js");
+    expect(typeof unarchiveRingCentralTeam).toBe("function");
+  });
+});
+
 describe("probeRingCentral", () => {
   it("should be exported", async () => {
     const { probeRingCentral } = await import("./api.js");

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import type {
   RingCentralEvent,
   RingCentralNote,
   RingCentralWebhook,
+  RingCentralTeam,
 } from "./types.js";
 
 // Team Messaging API endpoints
@@ -890,6 +891,148 @@ export async function suspendRingCentralWebhook(params: {
   const { account, webhookId } = params;
   const platform = await getRingCentralPlatform(account);
   await platform.post(`${TM_API_BASE}/webhooks/${webhookId}/suspend`, {});
+}
+
+// Teams API
+export async function listRingCentralTeams(params: {
+  account: ResolvedRingCentralAccount;
+  limit?: number;
+  pageToken?: string;
+}): Promise<{ records: RingCentralTeam[]; navigation?: { nextPageToken?: string } }> {
+  const { account, limit, pageToken } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const queryParams: Record<string, string> = {};
+  if (limit) queryParams.recordCount = String(limit);
+  if (pageToken) queryParams.pageToken = pageToken;
+
+  const response = await platform.get(`${TM_API_BASE}/teams`, queryParams);
+  const result = (await response.json()) as {
+    records?: RingCentralTeam[];
+    navigation?: { prevPageToken?: string; nextPageToken?: string };
+  };
+  return {
+    records: result.records ?? [],
+    navigation: result.navigation,
+  };
+}
+
+export async function createRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  name: string;
+  description?: string;
+  isPublic?: boolean;
+  members?: Array<{ id?: string; email?: string }>;
+}): Promise<RingCentralTeam> {
+  const { account, name, description, isPublic, members } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const body: Record<string, unknown> = { name };
+  if (description !== undefined) body.description = description;
+  if (isPublic !== undefined) body.public = isPublic;
+  if (members) body.members = members;
+
+  const response = await platform.post(`${TM_API_BASE}/teams`, body);
+  return (await response.json()) as RingCentralTeam;
+}
+
+export async function getRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<RingCentralTeam | null> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  try {
+    const response = await platform.get(`${TM_API_BASE}/teams/${teamId}`);
+    return (await response.json()) as RingCentralTeam;
+  } catch {
+    return null;
+  }
+}
+
+export async function updateRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+  name?: string;
+  description?: string;
+  isPublic?: boolean;
+}): Promise<RingCentralTeam> {
+  const { account, teamId, name, description, isPublic } = params;
+  const platform = await getRingCentralPlatform(account);
+
+  const body: Record<string, unknown> = {};
+  if (name !== undefined) body.name = name;
+  if (description !== undefined) body.description = description;
+  if (isPublic !== undefined) body.public = isPublic;
+
+  const response = await platform.patch(`${TM_API_BASE}/teams/${teamId}`, body);
+  return (await response.json()) as RingCentralTeam;
+}
+
+export async function deleteRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<void> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.delete(`${TM_API_BASE}/teams/${teamId}`);
+}
+
+export async function joinRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<void> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/join`, {});
+}
+
+export async function leaveRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<void> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/leave`, {});
+}
+
+export async function addRingCentralTeamMembers(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+  members: Array<{ id?: string; email?: string }>;
+}): Promise<void> {
+  const { account, teamId, members } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/add`, { members });
+}
+
+export async function removeRingCentralTeamMembers(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+  members: Array<{ id: string }>;
+}): Promise<void> {
+  const { account, teamId, members } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/remove`, { members });
+}
+
+export async function archiveRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<void> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/archive`, {});
+}
+
+export async function unarchiveRingCentralTeam(params: {
+  account: ResolvedRingCentralAccount;
+  teamId: string;
+}): Promise<void> {
+  const { account, teamId } = params;
+  const platform = await getRingCentralPlatform(account);
+  await platform.post(`${TM_API_BASE}/teams/${teamId}/unarchive`, {});
 }
 
 export async function probeRingCentral(

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,19 @@ export type RingCentralWebhook = {
   lastModifiedTime?: string;
 };
 
+export type RingCentralTeam = {
+  id?: string;
+  name?: string;
+  description?: string;
+  type?: "Team";
+  status?: "Active" | "Archived";
+  isPublic?: boolean;
+  creatorId?: string;
+  members?: Array<{ id?: string; email?: string }>;
+  creationTime?: string;
+  lastModifiedTime?: string;
+};
+
 export type RingCentralEvent = {
   id?: string;
   chatId?: string;


### PR DESCRIPTION
## Summary
Add comprehensive support for RingCentral Teams Management API with 11 endpoints.

## New APIs
- `listRingCentralTeams()` - List teams with pagination
- `createRingCentralTeam()` - Create team with name, description, visibility, initial members
- `getRingCentralTeam()` - Get single team by ID
- `updateRingCentralTeam()` - Update team name, description, visibility
- `deleteRingCentralTeam()` - Delete team
- `joinRingCentralTeam()` - Join a public team
- `leaveRingCentralTeam()` - Leave a team
- `addRingCentralTeamMembers()` - Add members by ID or email
- `removeRingCentralTeamMembers()` - Remove members by ID
- `archiveRingCentralTeam()` - Archive team
- `unarchiveRingCentralTeam()` - Restore archived team

## Changes
- Added `RingCentralTeam` type to `src/types.ts`
- Added 11 API functions to `src/api.ts`
- Added 11 tests (138 total passing)
- Updated README documentation

## Testing
All 138 tests pass. TypeScript type checking passes.

Required scope: `TeamMessaging`

**Note:** This branch is based on `feature/webhooks-api` (PR #17). Merge that first.