### PR TITLE
fix: update publish-beta workflow for GitHub Packages

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -39,16 +39,31 @@ jobs:
           echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
           echo "Beta version: $BETA_VERSION"
 
-      - name: Update package.json version
+      - name: Update package.json for GitHub Packages
         run: |
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+            // Update version
             pkg.version = '${{ steps.version.outputs.version }}';
+            // GitHub Packages requires scoped package name
+            pkg.name = '@${{ github.repository_owner }}/openclaw-ringcentral';
+            // Ensure publishConfig points to GitHub Packages
+            pkg.publishConfig = {
+              registry: 'https://npm.pkg.github.com'
+            };
+            // Update repository URL to match
+            pkg.repository = {
+              type: 'git',
+              url: 'https://github.com/${{ github.repository }}.git'
+            };
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('Updated package.json:');
+            console.log('  name:', pkg.name);
+            console.log('  version:', pkg.version);
           "
 
       - name: Publish to GitHub Packages
-        run: pnpm publish --no-git-checks --access public
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "index.ts",
   "description": "OpenClaw RingCentral Team Messaging channel plugin",
   "license": "MIT",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
- Change package name to scoped format (@owner/openclaw-ringcentral) at publish time
- Remove static publishConfig from package.json (set dynamically in CI)
- Use github.repository_owner and github.repository for dynamic values