### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in chat logging

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -221,11 +221,18 @@ function logVerbose(
   }
 }
 
+export function sanitizeFilename(name: string): string {
+  // Replace unsafe chars with underscore.
+  // We explicitly disallow dots to prevent path traversal via ".."
+  // RingCentral IDs are typically numeric, so this is safe.
+  return name.replace(/[^a-zA-Z0-9-_]/g, "_");
+}
+
 /**
  * Save group chat message to workspace memory file.
  * File path: ${workspace}/memory/chats/YYYY-MM-DD/${chatId}.md
  */
-async function saveGroupChatMessage(params: {
+export async function saveGroupChatMessage(params: {
   workspace: string;
   chatId: string;
   chatName?: string;
@@ -254,7 +261,8 @@ async function saveGroupChatMessage(params: {
 
     // Build file path
     const chatDir = path.join(workspace, "memory", "chats", dateStr);
-    const filePath = path.join(chatDir, `${chatId}.md`);
+    const safeChatId = sanitizeFilename(chatId);
+    const filePath = path.join(chatDir, `${safeChatId}.md`);
 
     // Ensure directory exists
     await fs.promises.mkdir(chatDir, { recursive: true });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal in Chat Logging
🎯 Impact: An attacker could potentially write files outside the intended directory by manipulating the `chatId` (e.g., via a malicious payload if the bot endpoint is exposed or if the ID is not numeric).
🔧 Fix: Implemented `sanitizeFilename` to strictly allow only alphanumeric characters, hyphens, and underscores in filenames. Used this sanitizer in `saveGroupChatMessage`.
✅ Verification: Added unit tests to `src/monitor.test.ts` verifying that path traversal attempts (e.g., `../../etc/passwd`) are sanitized to safe filenames (e.g., `______etc_passwd`).

---
*PR created automatically by Jules for task [11108775688478650360](https://jules.google.com/task/11108775688478650360) started by @danbao*