### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS risk in attachment download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2026-02-10 - [DoS Risk] Unchecked File Download Size
+**Vulnerability:** `downloadRingCentralAttachment` fetched the entire response body into memory using `arrayBuffer()` before checking if it exceeded `maxBytes`. This allowed large files to consume server memory, leading to potential Denial of Service.
+**Learning:** Functions consuming external content must validate size constraints as early as possible (e.g., via headers) before allocating memory for the full payload.
+**Prevention:** Check `Content-Length` header against limits before calling `arrayBuffer()` or consuming streams. Keep post-download checks as a fallback for missing or spoofed headers.

--- a/src/api.security.test.ts
+++ b/src/api.security.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+import { downloadRingCentralAttachment } from "./api.js";
+
+// Mock the auth module
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(),
+}));
+
+const mockAccount: ResolvedRingCentralAccount = {
+  accountId: "test",
+  enabled: true,
+  credentialSource: "config",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  jwt: "test-jwt",
+  server: "https://platform.ringcentral.com",
+  config: {},
+};
+
+describe("downloadRingCentralAttachment Security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw error if Content-Length exceeds maxBytes BEFORE calling arrayBuffer", async () => {
+    const { getRingCentralPlatform } = await import("./auth.js");
+    const mockArrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(10)); // Small buffer, but header says huge
+
+    const mockPlatform = {
+      get: vi.fn().mockResolvedValue({
+        headers: {
+          get: (name: string) => {
+            if (name.toLowerCase() === "content-length") return "1000000"; // 1MB
+            if (name.toLowerCase() === "content-type") return "text/plain";
+            return null;
+          },
+        },
+        arrayBuffer: mockArrayBuffer,
+      }),
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue(mockPlatform);
+
+    // Set maxBytes to 100 bytes
+    await expect(
+      downloadRingCentralAttachment({
+        account: mockAccount,
+        contentUri: "/restapi/v1.0/content/123",
+        maxBytes: 100,
+      })
+    ).rejects.toThrow("RingCentral attachment exceeds max bytes (100)");
+
+    // CRITICAL: Ensure arrayBuffer was NEVER called
+    expect(mockArrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("should download file if Content-Length is within limit", async () => {
+    const { getRingCentralPlatform } = await import("./auth.js");
+    const mockArrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(50));
+
+    const mockPlatform = {
+      get: vi.fn().mockResolvedValue({
+        headers: {
+          get: (name: string) => {
+            if (name.toLowerCase() === "content-length") return "50";
+            return null;
+          },
+        },
+        arrayBuffer: mockArrayBuffer,
+      }),
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue(mockPlatform);
+
+    const result = await downloadRingCentralAttachment({
+      account: mockAccount,
+      contentUri: "/restapi/v1.0/content/123",
+      maxBytes: 100,
+    });
+
+    expect(result.buffer).toBeDefined();
+    expect(mockArrayBuffer).toHaveBeenCalled();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -362,6 +362,18 @@ export async function downloadRingCentralAttachment(params: {
 
   const response = await platform.get(contentUri);
   const contentType = response.headers.get("content-type") ?? undefined;
+
+  // Security: Check Content-Length before downloading entire body
+  if (maxBytes) {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const length = parseInt(contentLength, 10);
+      if (!isNaN(length) && length > maxBytes) {
+        throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+      }
+    }
+  }
+
   const arrayBuffer = await response.arrayBuffer();
   
   if (maxBytes && arrayBuffer.byteLength > maxBytes) {


### PR DESCRIPTION
This PR fixes a potential Denial of Service (DoS) vulnerability in the `downloadRingCentralAttachment` function. Previously, the function would download the entire file content into memory using `response.arrayBuffer()` before checking if the size exceeded the `maxBytes` limit. This could allow an attacker to exhaust server memory by sending large files.

The fix implements an early check on the `Content-Length` header. If the header indicates the file is larger than the allowed limit, the download is aborted immediately without consuming the response body. The original size check after download is retained as a fallback for cases where the `Content-Length` header is missing or incorrect.

A new security test file `src/api.security.test.ts` has been added to verify this behavior and prevent regressions.


---
*PR created automatically by Jules for task [8212379758058293202](https://jules.google.com/task/8212379758058293202) started by @danbao*