### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix DoS via unbound attachment download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-14 - [DoS Protection]
+**Vulnerability:** `downloadRingCentralAttachment` read the entire response body into memory before checking `maxBytes`. This allowed attackers (or accidental large files) to cause memory exhaustion (DoS).
+**Learning:** Always validate `Content-Length` headers before consuming the response body when dealing with user-supplied or potentially large content.
+**Prevention:** Added a pre-flight check against `Content-Length` in `src/api.ts`.

--- a/src/api.security.test.ts
+++ b/src/api.security.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+import { downloadRingCentralAttachment } from "./api.js";
+
+// Mock getRingCentralPlatform
+const mockPlatform = {
+  get: vi.fn(),
+};
+
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(() => Promise.resolve(mockPlatform)),
+}));
+
+const mockAccount: ResolvedRingCentralAccount = {
+  accountId: "test-account",
+  enabled: true,
+  credentialSource: "config",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  jwt: "jwt-token",
+  server: "https://platform.ringcentral.com",
+  config: {},
+};
+
+describe("downloadRingCentralAttachment Security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw error BEFORE reading body if Content-Length exceeds maxBytes", async () => {
+    const maxBytes = 100;
+    const largeSize = maxBytes + 10;
+
+    const arrayBufferMock = vi.fn().mockResolvedValue(new ArrayBuffer(largeSize));
+
+    mockPlatform.get.mockResolvedValue({
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === "content-length") return String(largeSize);
+          if (name.toLowerCase() === "content-type") return "text/plain";
+          return null;
+        },
+      },
+      arrayBuffer: arrayBufferMock,
+    });
+
+    await expect(
+      downloadRingCentralAttachment({
+        account: mockAccount,
+        contentUri: "https://example.com/file",
+        maxBytes,
+      })
+    ).rejects.toThrow(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+
+    // KEY CHECK: ensure arrayBuffer was NOT called
+    expect(arrayBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("should throw error AFTER reading body if Content-Length is missing but body exceeds maxBytes", async () => {
+    const maxBytes = 100;
+    const largeSize = maxBytes + 10;
+
+    const arrayBufferMock = vi.fn().mockResolvedValue(new ArrayBuffer(largeSize));
+
+    mockPlatform.get.mockResolvedValue({
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === "content-type") return "text/plain";
+          return null; // Content-Length missing
+        },
+      },
+      arrayBuffer: arrayBufferMock,
+    });
+
+    await expect(
+      downloadRingCentralAttachment({
+        account: mockAccount,
+        contentUri: "https://example.com/file",
+        maxBytes,
+      })
+    ).rejects.toThrow(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+
+    // KEY CHECK: ensure arrayBuffer WAS called (fallback behavior)
+    expect(arrayBufferMock).toHaveBeenCalled();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -362,6 +362,17 @@ export async function downloadRingCentralAttachment(params: {
 
   const response = await platform.get(contentUri);
   const contentType = response.headers.get("content-type") ?? undefined;
+
+  if (maxBytes) {
+    const contentLengthStr = response.headers.get("content-length");
+    if (contentLengthStr) {
+      const contentLength = parseInt(contentLengthStr, 10);
+      if (!isNaN(contentLength) && contentLength > maxBytes) {
+        throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+      }
+    }
+  }
+
   const arrayBuffer = await response.arrayBuffer();
   
   if (maxBytes && arrayBuffer.byteLength > maxBytes) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `downloadRingCentralAttachment` read the entire response body into memory before checking the `maxBytes` limit, allowing for potential Memory Exhaustion (DoS).
🎯 Impact: Attackers or large files could cause the application to crash or become unresponsive due to excessive memory usage.
🔧 Fix: Added a pre-flight check for the `Content-Length` header. If it exceeds `maxBytes`, the download is aborted immediately.
✅ Verification: Added `src/api.security.test.ts` which verifies that `arrayBuffer()` is not called if `Content-Length` is too large. Ran `pnpm test` and all tests passed.

---
*PR created automatically by Jules for task [14643338265910387815](https://jules.google.com/task/14643338265910387815) started by @danbao*