### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential DoS in attachment download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-10 - DoS via large file downloads in RingCentral attachments
+**Vulnerability:** `downloadRingCentralAttachment` read the entire response body into memory via `arrayBuffer()` before checking if it exceeded `maxBytes`. This could lead to a Denial of Service (DoS) via memory exhaustion if a malicious actor sent a very large file.
+**Learning:** Checking size limits *after* downloading defeats the purpose of the limit for memory protection.
+**Prevention:** Always check `Content-Length` header (if available) before consuming the response body. Ideally, use stream processing with a byte counter for robust protection even when `Content-Length` is missing or spoofed.

--- a/src/api.security.test.ts
+++ b/src/api.security.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+import { downloadRingCentralAttachment } from "./api.js";
+import { getRingCentralPlatform } from "./auth.js";
+
+// Mock the auth module
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(),
+}));
+
+const mockAccount: ResolvedRingCentralAccount = {
+  accountId: "test",
+  enabled: true,
+  credentialSource: "config",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  jwt: "test-jwt",
+  server: "https://platform.ringcentral.com",
+  config: {},
+};
+
+describe("Security: downloadRingCentralAttachment", () => {
+  const mockPlatform = {
+    get: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getRingCentralPlatform as any).mockResolvedValue(mockPlatform);
+  });
+
+  it("should prevent download if Content-Length exceeds maxBytes", async () => {
+    const maxBytes = 1024; // 1KB
+    const contentLength = 2048; // 2KB
+
+    const arrayBufferSpy = vi.fn().mockResolvedValue(new ArrayBuffer(contentLength));
+
+    mockPlatform.get.mockResolvedValue({
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === "content-length") return String(contentLength);
+          if (name.toLowerCase() === "content-type") return "text/plain";
+          return null;
+        },
+      },
+      arrayBuffer: arrayBufferSpy,
+    });
+
+    await expect(
+      downloadRingCentralAttachment({
+        account: mockAccount,
+        contentUri: "https://example.com/file.txt",
+        maxBytes,
+      })
+    ).rejects.toThrow(/exceeds max bytes/);
+
+    // CRITICAL: arrayBuffer must NOT be called if Content-Length check works
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+
+  it("should succeed if Content-Length is within limit", async () => {
+    const maxBytes = 1024;
+    const contentLength = 512;
+
+    const arrayBufferSpy = vi.fn().mockResolvedValue(new ArrayBuffer(contentLength));
+
+    mockPlatform.get.mockResolvedValue({
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === "content-length") return String(contentLength);
+          if (name.toLowerCase() === "content-type") return "text/plain";
+          return null;
+        },
+      },
+      arrayBuffer: arrayBufferSpy,
+    });
+
+    const result = await downloadRingCentralAttachment({
+      account: mockAccount,
+      contentUri: "https://example.com/file.txt",
+      maxBytes,
+    });
+
+    expect(result.buffer.byteLength).toBe(contentLength);
+    expect(arrayBufferSpy).toHaveBeenCalled();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -362,6 +362,18 @@ export async function downloadRingCentralAttachment(params: {
 
   const response = await platform.get(contentUri);
   const contentType = response.headers.get("content-type") ?? undefined;
+
+  // Security: Check Content-Length before downloading to prevent DoS via memory exhaustion
+  if (maxBytes) {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const length = parseInt(contentLength, 10);
+      if (!isNaN(length) && length > maxBytes) {
+        throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+      }
+    }
+  }
+
   const arrayBuffer = await response.arrayBuffer();
   
   if (maxBytes && arrayBuffer.byteLength > maxBytes) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `downloadRingCentralAttachment` previously read the entire response body into memory before checking the `maxBytes` limit, allowing attackers to cause memory exhaustion (OOM) via large files.
🎯 Impact: Denial of Service (DoS) if a malicious actor sends a very large file.
🔧 Fix: Added a check for `Content-Length` header before consuming the response body.
✅ Verification: Added `src/api.security.test.ts` which verifies that `arrayBuffer()` is not called if `Content-Length` exceeds `maxBytes`.

---
*PR created automatically by Jules for task [10410695552377574326](https://jules.google.com/task/10410695552377574326) started by @danbao*