### PR TITLE
🛡️ Sentinel: Fix potential DoS in attachment download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-10 - Unbounded Memory Consumption in File Downloads
+**Vulnerability:** The `downloadRingCentralAttachment` function buffered entire file downloads into memory using `response.arrayBuffer()` before checking `maxBytes`, allowing malicious or large files to cause Out-Of-Memory (OOM) crashes (DoS).
+**Learning:** Checking size limits *after* a full download defeats the purpose of resource protection. Stream processing is essential for handling untrusted external content.
+**Prevention:** Always consume response bodies as streams (Web `ReadableStream` or Node `Readable`), accumulate chunks incrementally, and abort the stream immediately if a size limit is exceeded.

--- a/src/api-security.test.ts
+++ b/src/api-security.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { downloadRingCentralAttachment } from "./api.js";
+import { Readable } from "stream";
+
+// Mock auth
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(),
+}));
+
+import { getRingCentralPlatform } from "./auth.js";
+
+describe("downloadRingCentralAttachment Security", () => {
+  it("should stream (Node Readable) and abort download if size exceeds maxBytes", async () => {
+    const mockAccount: any = { accountId: "test" };
+    const maxBytes = 10;
+
+    // Create a stream that is larger than maxBytes
+    const largeContent = Buffer.alloc(maxBytes + 100);
+    const bodyStream = Readable.from(largeContent);
+
+    const mockResponse = {
+      headers: { get: () => "text/plain" },
+      // arrayBuffer should NOT be called in the improved implementation
+      arrayBuffer: vi.fn().mockRejectedValue(new Error("Should not use arrayBuffer")),
+      body: bodyStream,
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue({
+      get: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    await expect(downloadRingCentralAttachment({
+      account: mockAccount,
+      contentUri: "http://example.com/file",
+      maxBytes
+    })).rejects.toThrow(/exceeds max bytes/);
+  });
+
+  it("should stream (Web ReadableStream) and abort download if size exceeds maxBytes", async () => {
+    const mockAccount: any = { accountId: "test" };
+    const maxBytes = 10;
+
+    // Mock a Web ReadableStream
+    const largeContent = new Uint8Array(maxBytes + 100);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(largeContent);
+        controller.close();
+      }
+    });
+
+    // Mock cancellation spy
+    const cancelSpy = vi.fn();
+    // We need to inject the cancel spy into the stream reader or stream itself
+    // But since ReadableStream is standard, we can verify the behavior by the error thrown.
+    // However, to be precise, let's just rely on the error thrown by our code.
+
+    // In our implementation we call reader.cancel().
+    // We can spy on the reader.
+
+    const mockReader = {
+      read: vi.fn()
+        .mockResolvedValueOnce({ done: false, value: largeContent })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: cancelSpy,
+      releaseLock: vi.fn(),
+    };
+
+    const mockBody = {
+      getReader: () => mockReader
+    };
+
+    const mockResponse = {
+      headers: { get: () => "text/plain" },
+      arrayBuffer: vi.fn().mockRejectedValue(new Error("Should not use arrayBuffer")),
+      body: mockBody,
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue({
+      get: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    await expect(downloadRingCentralAttachment({
+      account: mockAccount,
+      contentUri: "http://example.com/webstream",
+      maxBytes
+    })).rejects.toThrow(/exceeds max bytes/);
+
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 What
Refactored `downloadRingCentralAttachment` to use streaming processing instead of buffering the entire file into memory.

⚠️ Risk
The previous implementation used `response.arrayBuffer()`, which reads the entire response body into memory before checking the `maxBytes` limit. This allowed a malicious or unexpectedly large file to cause an Out-Of-Memory (OOM) crash, leading to a Denial of Service (DoS).

🛡️ Solution
Implemented a streaming download mechanism that supports both Web Streams (`ReadableStream`) and Node.js Streams (`Readable`). The download now aborts immediately if the accumulated size exceeds `maxBytes`, preventing memory exhaustion.

✅ Verification
Added `src/api-security.test.ts` which mocks both stream types and verifies that the download is aborted when the size limit is exceeded. Verified that `arrayBuffer()` is no longer called in the streaming path. All existing tests passed.

---
*PR created automatically by Jules for task [13843066990033527719](https://jules.google.com/task/13843066990033527719) started by @danbao*