### PR TITLE
🛡️ Sentinel: Fix memory exhaustion in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-10-27 - File Download Memory Exhaustion
+**Vulnerability:** The `downloadRingCentralAttachment` function used `response.arrayBuffer()` to load entire files into memory before checking `maxBytes`, exposing the application to Denial of Service (DoS) via memory exhaustion.
+**Learning:** `fetch` API methods like `arrayBuffer()` buffer the entire response. Size limits must be enforced during stream consumption, not after buffering.
+**Prevention:** Always use streaming (Web Streams or Node Streams) for file downloads and enforce size limits incrementally as chunks are received.

--- a/src/api-security.test.ts
+++ b/src/api-security.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { downloadRingCentralAttachment } from "./api.js";
+import { Readable } from "stream";
+import { getRingCentralPlatform } from "./auth.js";
+
+// Mock the auth module
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(),
+}));
+
+const mockAccount = {
+  accountId: "test",
+  enabled: true,
+  credentialSource: "config",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  jwt: "test-jwt",
+  server: "https://platform.ringcentral.com",
+  config: {},
+};
+
+describe("downloadRingCentralAttachment Security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should enforce maxBytes limit using stream and NOT call arrayBuffer", async () => {
+    const hugeSize = 1024 * 1024 * 10; // 10MB
+    const maxBytes = 1024 * 1024 * 1; // 1MB
+
+    const mockResponse = {
+      headers: {
+        get: () => "application/octet-stream",
+      },
+      arrayBuffer: vi.fn().mockImplementation(async () => {
+        return new ArrayBuffer(hugeSize);
+      }),
+      // Simulate Node.js Readable stream
+      body: Readable.from(async function* () {
+        // Yield chunks
+        for (let i = 0; i < 10; i++) {
+          yield Buffer.alloc(1024 * 1024); // 1MB chunks
+        }
+      }()),
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue({
+      get: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    await expect(downloadRingCentralAttachment({
+      account: mockAccount as any,
+      contentUri: "https://example.com/hugefile",
+      maxBytes: maxBytes,
+    })).rejects.toThrow(/RingCentral attachment exceeds max bytes/);
+
+    // KEY CHECK: arrayBuffer should NOT be called because we used the stream
+    expect(mockResponse.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("should enforce maxBytes limit with Web Streams", async () => {
+      const maxBytes = 10;
+      const cancelSpy = vi.fn();
+      const readSpy = vi.fn()
+          .mockResolvedValueOnce({ done: false, value: new Uint8Array(5) })
+          .mockResolvedValueOnce({ done: false, value: new Uint8Array(10) }) // Total 15 > 10
+          .mockResolvedValue({ done: true, value: undefined });
+
+      const mockReader = {
+          read: readSpy,
+          cancel: cancelSpy,
+          releaseLock: vi.fn(),
+      };
+
+      const mockResponse = {
+          headers: { get: () => "text/plain" },
+          body: {
+              getReader: () => mockReader,
+          },
+          arrayBuffer: vi.fn(),
+      };
+
+      (getRingCentralPlatform as any).mockResolvedValue({
+          get: vi.fn().mockResolvedValue(mockResponse),
+      });
+
+      await expect(downloadRingCentralAttachment({
+          account: mockAccount as any,
+          contentUri: "https://example.com/stream",
+          maxBytes: maxBytes,
+      })).rejects.toThrow(/RingCentral attachment exceeds max bytes/);
+
+      expect(cancelSpy).toHaveBeenCalled();
+      expect(mockResponse.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("should download valid file correctly using stream", async () => {
+    const content = Buffer.from("Hello World");
+    const mockResponse = {
+      headers: {
+        get: () => "text/plain",
+      },
+      body: Readable.from([content]),
+      arrayBuffer: vi.fn(),
+    };
+
+    (getRingCentralPlatform as any).mockResolvedValue({
+      get: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    const result = await downloadRingCentralAttachment({
+      account: mockAccount as any,
+      contentUri: "https://example.com/file",
+      maxBytes: 100,
+    });
+
+    expect(result.buffer.toString()).toBe("Hello World");
+    expect(result.contentType).toBe("text/plain");
+    expect(mockResponse.arrayBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -362,14 +362,68 @@ export async function downloadRingCentralAttachment(params: {
 
   const response = await platform.get(contentUri);
   const contentType = response.headers.get("content-type") ?? undefined;
-  const arrayBuffer = await response.arrayBuffer();
-  
-  if (maxBytes && arrayBuffer.byteLength > maxBytes) {
-    throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+  const body = response.body;
+
+  if (!body) {
+    return { buffer: Buffer.alloc(0), contentType };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+
+  // Handle Web Streams (standard fetch)
+  if (typeof (body as any).getReader === "function") {
+    const reader = (body as any).getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          bytesRead += value.length;
+          if (maxBytes && bytesRead > maxBytes) {
+            await reader.cancel();
+            throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+          }
+          chunks.push(value);
+        }
+      }
+    } finally {
+      // Release lock if stream is still locked (e.g. error but not cancelled)
+      // Note: If we called cancel(), the lock is released when the cancel promise resolves
+      // but releaseLock() is safe to call if the reader is no longer active.
+      // However, if we threw an error, we might still have the lock.
+      // Basic safeguard:
+      try { reader.releaseLock(); } catch { /* ignore if already released */ }
+    }
+  }
+  // Handle Node.js Streams / Async Iterables (node-fetch)
+  else if (typeof (body as any)[Symbol.asyncIterator] === "function" || typeof (body as any).on === "function") {
+    for await (const chunk of (body as any)) {
+      const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytesRead += bufferChunk.length;
+      if (maxBytes && bytesRead > maxBytes) {
+        if (typeof (body as any).destroy === "function") {
+          (body as any).destroy();
+        }
+        throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+      }
+      chunks.push(bufferChunk);
+    }
+  }
+  // Fallback to arrayBuffer if no stream interface found
+  else {
+    const arrayBuffer = await response.arrayBuffer();
+    if (maxBytes && arrayBuffer.byteLength > maxBytes) {
+      throw new Error(`RingCentral attachment exceeds max bytes (${maxBytes})`);
+    }
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      contentType,
+    };
   }
 
   return {
-    buffer: Buffer.from(arrayBuffer),
+    buffer: Buffer.concat(chunks),
     contentType,
   };
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `downloadRingCentralAttachment` function was reading the entire file into memory using `arrayBuffer()` before checking the `maxBytes` limit. This allowed attackers to send large files and exhaust server memory (DoS).
🎯 Impact: Potential server crash due to Out of Memory (OOM) error.
🔧 Fix: Refactored the function to use streaming (supporting both Web Streams and Node.js Streams). It now reads the file in chunks and throws an error immediately if the size exceeds `maxBytes`, preventing excessive memory usage.
✅ Verification: Added `src/api-security.test.ts` which verifies that `arrayBuffer()` is not called and that the function throws when the stream size exceeds the limit.

---
*PR created automatically by Jules for task [1169327807465798848](https://jules.google.com/task/1169327807465798848) started by @danbao*