### PR TITLE
fix: WS pipeline hardening and routing fixes (cherry-pick from PR #81)

### DIFF
--- a/src/monitor-security.test.ts
+++ b/src/monitor-security.test.ts
@@ -54,12 +54,19 @@ describe("summarizeEvent", () => {
     expect(result).toEqual({
       event: "/restapi/v1.0/glip/posts",
       subscriptionId: "sub-456",
+      shape: {
+        hasBody: true,
+        bodyKeys: "creatorId,eventType,groupId,id,mentions,text,type",
+      },
       body: {
         id: "post-1",
         groupId: "group-1",
         type: "TextMessage",
         eventType: "PostAdded",
         creatorId: "user-1",
+        hasText: true,
+        attachmentCount: null,
+        mentionCount: 1,
       },
     });
     expect(result.body.text).toBeUndefined();
@@ -74,6 +81,11 @@ describe("summarizeEvent", () => {
 
   it("handles event without body", () => {
     const result = JSON.parse(summarizeEvent({ event: "/test" }));
-    expect(result).toEqual({ event: "/test", subscriptionId: null, body: null });
+    expect(result).toEqual({
+      event: "/test",
+      subscriptionId: null,
+      shape: { hasBody: false, bodyKeys: null },
+      body: null,
+    });
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -399,16 +399,24 @@ export function summarizeChatInfo(chat: unknown): string {
 export function summarizeEvent(event: unknown): string {
   if (!event || typeof event !== "object") return "null";
   const e = event as Record<string, unknown>;
-  const body = (e.body && typeof e.body === "object") ? e.body as Record<string, unknown> : null;
+  const body = (e.body && typeof e.body === "object") ? (e.body as Record<string, unknown>) : null;
+  const bodyKeys = body ? Object.keys(body).sort() : [];
   return JSON.stringify({
     event: e.event ?? null,
     subscriptionId: e.subscriptionId ?? null,
+    shape: {
+      hasBody: Boolean(body),
+      bodyKeys: bodyKeys.length > 0 ? bodyKeys.join(",") : null,
+    },
     body: body ? {
       id: body.id ?? null,
       groupId: body.groupId ?? null,
       type: body.type ?? null,
       eventType: body.eventType ?? null,
       creatorId: body.creatorId ?? null,
+      hasText: Boolean(body.text),
+      attachmentCount: Array.isArray(body.attachments) ? (body.attachments as unknown[]).length : null,
+      mentionCount: Array.isArray(body.mentions) ? (body.mentions as unknown[]).length : null,
     } : null,
   });
 }
@@ -588,19 +596,45 @@ async function processMessageWithPipeline(params: {
   const logger = getLogger(core);
   const mediaMaxMb = account.config.mediaMaxMb ?? 20;
 
-  const chatId = eventBody.groupId ?? "";
+  const chatId = String(eventBody.groupId ?? "");
   if (!chatId) return;
 
   const senderId = eventBody.creatorId ?? "";
-  const messageText = (eventBody.text ?? "").trim();
-  const attachments = eventBody.attachments ?? [];
+
+  // Some WS notifications only include post id/groupId without `text`.
+  // Fetch the full post content before routing (only for PostAdded events).
+  let fullEventBody = eventBody;
+  if (!fullEventBody.text && fullEventBody.id && fullEventBody.eventType === "PostAdded") {
+    try {
+      const mgr = wsManagers.get(account.accountId);
+      const platform = mgr?.sdk?.platform();
+      if (!platform) {
+        logger.warn(`[${account.accountId}] Enrich skipped: sdk/platform not ready (postId=${fullEventBody.id})`);
+      } else {
+        const r = await platform.get(`/restapi/v1.0/glip/posts/${fullEventBody.id}`);
+        const post = await r.json();
+        fullEventBody = { ...fullEventBody, ...post };
+        logger.debug(`[${account.accountId}] Enriched post ${fullEventBody.id} via REST`);
+      }
+    } catch (e) {
+      logger.warn(`[${account.accountId}] Failed to enrich post ${fullEventBody.id}: ${String(e)}`);
+    }
+  }
+
+  const messageText = (fullEventBody.text ?? "").trim();
+  const attachments = fullEventBody.attachments ?? [];
   const hasMedia = attachments.length > 0;
   const rawBody = messageText || (hasMedia ? "<media:attachment>" : "");
-  if (!rawBody) return;
+  if (!rawBody) {
+    logger.warn(
+      `[${account.accountId}] DROP:empty_rawBody (postId=${fullEventBody.id ?? ""} chatId=${chatId} sender=${senderId})`,
+    );
+    return;
+  }
 
   // Skip bot's own messages to avoid infinite loop
   // Check 1: Skip if this is a message we recently sent
-  const messageId = eventBody.id ?? "";
+  const messageId = fullEventBody.id ?? "";
   if (messageId && isOwnSentMessage(messageId)) {
     logVerbose(core, `skip own sent message: ${messageId}`);
     return;
@@ -702,26 +736,32 @@ async function processMessageWithPipeline(params: {
     : "";
 
   // Map RingCentral chat types to openclaw peerKind:
-  // - Personal/Direct -> "dm" (direct message)
+  // - Personal/Direct -> "direct" (direct message)
   // - Group -> "group" (small group chat, 3-16 people)
   // - Team -> "channel" (named team chat, similar to Slack channel)
-  const peerKind: "dm" | "group" | "channel" = isGroup
+  const peerKind: "direct" | "group" | "channel" = isGroup
     ? chatType === "Team"
       ? "channel"
       : "group"
-    : "dm";
+    : "direct";
 
+  const routePeerId = String(isGroup ? chatId : (dmPeerUserId || chatId));
   const route = core.channel.routing.resolveAgentRoute({
     cfg: config,
     channel: "ringcentral",
     accountId: account.accountId,
     peer: {
       kind: peerKind,
-      id: isGroup ? chatId : (dmPeerUserId || chatId),
+      id: routePeerId,
     },
   });
 
   logger.debug(`[${account.accountId}] Chat type: ${chatType}, isGroup: ${isGroup}`);
+  logger.debug(
+    `[${account.accountId}] resolvedRoute: channel=ringcentral accountId=${account.accountId}` +
+    ` peerKind=${peerKind} peerId=${routePeerId}` +
+    ` -> agentId=${(route as any)?.agentId ?? "(default)"} matchedBy=${(route as any)?.matchedBy ?? "unknown"}`,
+  );
 
   // In selfOnly mode, only allow "Personal" chat (conversation with yourself)
   if (selfOnly && !isPersonalChat) {
@@ -888,7 +928,7 @@ async function processMessageWithPipeline(params: {
 
   if (isGroup) {
     const requireMention = groupEntry?.requireMention ?? account.config.requireMention ?? true;
-    const mentions = eventBody.mentions ?? [];
+    const mentions = fullEventBody.mentions ?? [];
     const mentionInfo = extractMentionInfo(mentions, account.config.botExtensionId);
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg: config,
@@ -1274,6 +1314,9 @@ async function deliverRingCentralReply(params: {
             postId: typingPostId,
             text: chunk,
           });
+          logger.debug(
+            `[${account.accountId}] RC_POST_UPDATE_OK chatId=${chatId} postId=${typingPostId} len=${chunk.length}`,
+          );
           if (updateResult?.postId) trackSentMessageId(updateResult.postId);
         } else {
           const sendResult = await sendRingCentralMessage({
@@ -1287,6 +1330,9 @@ async function deliverRingCentralReply(params: {
       } catch (err) {
         const errInfo = formatRcApiError(extractRcApiError(err, account.accountId));
         logger.error(`RingCentral message send failed: ${errInfo}`);
+        logger.error(
+          `[${account.accountId}] RC_POST_UPDATE_FAIL chatId=${chatId} typingPostId=${typingPostId ?? ""} chunkIndex=${i} err=${errInfo}`,
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Cherry-pick 有价值的修复从 PR #81，排除有问题的改动。

## Cherry-picked 改动

### 1. String() 强制类型转换 (chatId / peerId)
RingCentral 有时返回 number 类型 id，不转换会导致 `[object Object]` 出现在日志和路由中。

### 2. peerKind `"dm"` → `"direct"`
与 openclaw 内置 channel (Telegram/Discord) 保持一致，消除对 normalizeChatType 隐式归一化的依赖。

### 3. REST enrich for PostAdded events
部分 WS 通知仅包含 post id/groupId 而无 `text`。对 `eventType === "PostAdded"` 的事件通过 REST 补全内容。仅对 PostAdded 生效，避免对系统事件发起不必要的 REST 调用。

### 4. summarizeEvent shape 指纹
增加 `bodyKeys`、`hasText`、`attachmentCount`、`mentionCount` 到诊断输出，不泄露敏感内容。

### 5. 路由 observability 日志
记录 `peerKind/peerId/agentId/matchedBy`，方便调试 binding 匹配问题。

### 6. RC_POST_UPDATE_OK/FAIL 日志
typing → answer 更新路径的可观测性补充。

### 7. empty rawBody warn + drop
空消息体现在会记录 warn 日志（含 postId/chatId/senderId）而非静默丢弃。

### 8. mentions 使用 enriched fullEventBody
确保 enrich 后的 mentions 数据用于 mention gating。

## 未包含的改动（需返工）

- **dmChats early gate** — 引入未声明的 config 字段 `dmChats`，破坏 selfOnly 默认流程
- **chatInfoLookupOk fallback** — chatInfo 失败时 fallback 到 Personal 比 Group 更危险（绕过 group policy）
- **WS_RAW_ENABLED** — 将消息原文打印到日志，存在隐私/安全风险

## Testing
- TypeScript typecheck: pass
- 244/244 tests pass