### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in attachment downloads

### DIFF
--- a/src/monitor-security.test.ts
+++ b/src/monitor-security.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { summarizeChatInfo, summarizeEvent } from "./monitor.js";
+import { sanitizeAttachmentFilename, summarizeChatInfo, summarizeEvent } from "./monitor.js";
+
+describe("sanitizeAttachmentFilename", () => {
+  it("allows safe filenames", () => {
+    expect(sanitizeAttachmentFilename("image.png")).toBe("image.png");
+    expect(sanitizeAttachmentFilename("document-v1.pdf")).toBe("document-v1.pdf");
+    expect(sanitizeAttachmentFilename("my_file.txt")).toBe("my_file.txt");
+  });
+
+  it("replaces unsafe characters", () => {
+    expect(sanitizeAttachmentFilename("foo/bar.txt")).toBe("foo_bar.txt");
+    expect(sanitizeAttachmentFilename("foo\\bar.txt")).toBe("foo_bar.txt");
+    expect(sanitizeAttachmentFilename("file with spaces.txt")).toBe("file_with_spaces.txt");
+    expect(sanitizeAttachmentFilename("foo*bar.txt")).toBe("foo_bar.txt");
+  });
+
+  it("prevents path traversal via ..", () => {
+    expect(sanitizeAttachmentFilename("../etc/passwd")).toBe("__etc_passwd");
+    expect(sanitizeAttachmentFilename("..\\windows\\system32")).toBe("__windows_system32");
+    expect(sanitizeAttachmentFilename("foo/../bar")).toBe("foo___bar");
+  });
+
+  it("handles multiple dots safely", () => {
+    expect(sanitizeAttachmentFilename("foo..bar")).toBe("foo_bar");
+    expect(sanitizeAttachmentFilename(".../test")).toBe("__test");
+  });
+});
 
 describe("summarizeChatInfo", () => {
   it("extracts only safe fields from chat object", () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1192,6 +1192,14 @@ async function processMessageWithPipeline(params: {
   }
 }
 
+export function sanitizeAttachmentFilename(name: string): string {
+  // Replace unsafe chars (including / and \) with underscore.
+  // We explicitly disallow everything except alphanumeric, dot, dash, underscore.
+  const safe = name.replace(/[^a-zA-Z0-9-_\.]/g, "_");
+  // Prevent multiple dots which could form ".."
+  return safe.replace(/\.\.+/g, "_");
+}
+
 async function downloadAttachment(
   attachment: RingCentralAttachment,
   account: ResolvedRingCentralAccount,
@@ -1207,7 +1215,7 @@ async function downloadAttachment(
     downloaded.contentType ?? attachment.contentType,
     "inbound",
     maxBytes,
-    attachment.name,
+    attachment.name ? sanitizeAttachmentFilename(attachment.name) : undefined,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
🎯 What
Added `sanitizeAttachmentFilename` to `src/monitor.ts` and updated `downloadAttachment` to use it.
The new function sanitizes attachment filenames by allowing only alphanumeric characters, dashes, underscores, and dots. It also explicitly neutralizes `..` sequences to prevent path traversal.

⚠️ Risk
Without this sanitization, malicious attachment filenames (e.g., `../../etc/passwd`) could potentially be used to write files outside the intended directory via `saveMediaBuffer`, leading to path traversal vulnerabilities.

🛡️ Solution
Implemented strict allowlist-based sanitization for attachment filenames.
Added comprehensive tests in `src/monitor-security.test.ts` to verify the sanitization logic.

✅ Verification
Run `pnpm test src/monitor-security.test.ts` to verify the fix.
Run `pnpm test` to ensure no regressions.

---
*PR created automatically by Jules for task [8058601216193697373](https://jules.google.com/task/8058601216193697373) started by @danbao*