### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS risk in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-24 - Missing Default Limits for File Downloads
+**Vulnerability:** The `downloadRingCentralAttachment` function allowed downloading files of arbitrary size into memory when the optional `maxBytes` parameter was omitted. This created a potential Denial of Service (DoS) vector via memory exhaustion (OOM).
+**Learning:** Optional security parameters in utility functions often lead to insecure defaults. Callers may assume a safe default exists or simply forget to provide the parameter.
+**Prevention:** Enforce safe defaults within the utility function itself. If a parameter is critical for security (like resource limits), make it mandatory or provide a conservative default value that safeguards the system.

--- a/src/api-security.test.ts
+++ b/src/api-security.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ResolvedRingCentralAccount } from "./accounts.js";
+
+// Mock the auth module
+vi.mock("./auth.js", () => ({
+  getRingCentralPlatform: vi.fn(),
+}));
+
+const mockAccount: ResolvedRingCentralAccount = {
+  accountId: "test",
+  enabled: true,
+  credentialSource: "config",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  jwt: "test-jwt",
+  server: "https://platform.ringcentral.com",
+  config: {},
+};
+
+describe("downloadRingCentralAttachment DoS protection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses streaming path with default limit when maxBytes is missing (safe behavior)", async () => {
+    const { getRingCentralPlatform } = await import("./auth.js");
+    const { downloadRingCentralAttachment } = await import("./api.js");
+
+    const mockArrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(10));
+    const mockGetReader = vi.fn().mockReturnValue({
+      read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+      releaseLock: vi.fn(),
+      cancel: vi.fn(),
+    });
+
+    const response = {
+      headers: {
+        get: () => "application/octet-stream",
+      },
+      body: {
+        getReader: mockGetReader,
+      },
+      arrayBuffer: mockArrayBuffer,
+    };
+
+    vi.mocked(getRingCentralPlatform).mockResolvedValue({
+      get: vi.fn().mockResolvedValue(response),
+    } as any);
+
+    // Call without maxBytes
+    await downloadRingCentralAttachment({ account: mockAccount, contentUri: "/safe" });
+
+    // Assert that we used the safe streaming path
+    expect(mockArrayBuffer).not.toHaveBeenCalled();
+    expect(mockGetReader).toHaveBeenCalled();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -357,7 +357,9 @@ export async function downloadRingCentralAttachment(params: {
   contentUri: string;
   maxBytes?: number;
 }): Promise<{ buffer: Buffer; contentType?: string }> {
-  const { account, contentUri, maxBytes } = params;
+  const { account, contentUri, maxBytes: providedMaxBytes } = params;
+  // Default to 50MB if no limit is provided to prevent memory exhaustion
+  const maxBytes = providedMaxBytes ?? 50 * 1024 * 1024;
   const platform = await getRingCentralPlatform(account);
 
   const response = await platform.get(contentUri);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing default size limit in `downloadRingCentralAttachment`. If a caller omitted `maxBytes`, the function would attempt to buffer the entire file into memory using `response.arrayBuffer()`.
🎯 Impact: An attacker could send a very large file, causing the application to crash with an Out of Memory (OOM) error (Denial of Service) if the function was called without an explicit limit.
🔧 Fix: Enforced a default limit of 50MB (`DEFAULT_MAX_BYTES`) when `maxBytes` is not provided. This ensures the function always uses the safe, streaming code path that validates content length.
✅ Verification: Added `src/api-security.test.ts` which asserts that `arrayBuffer()` is NOT called and `getReader()` IS called when `maxBytes` is omitted. Ran `pnpm test` to confirm all tests pass.

---
*PR created automatically by Jules for task [10423602896383075239](https://jules.google.com/task/10423602896383075239) started by @danbao*