### PR TITLE
fix: improve RingCentral error handling and resilience

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1084,3 +1084,38 @@ export async function probeRingCentral(
     };
   }
 }
+
+export async function checkWsSubscriptionPermission(
+  account: ResolvedRingCentralAccount,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const platform = await getRingCentralPlatform(account);
+    // Attempt a dry-run subscription to check permissions.
+    // Creating a real subscription and immediately deleting is too invasive,
+    // so we POST and catch the 403/SUB-528 to detect the missing permission.
+    const response = await platform.post("/restapi/v1.0/subscription", {
+      deliveryMode: { transportType: "WebSocket" },
+      eventFilters: ["/restapi/v1.0/glip/posts"],
+    });
+    // If it succeeds, clean up the test subscription
+    const body = await response.json();
+    if (body?.id) {
+      try {
+        await platform.delete(`/restapi/v1.0/subscription/${body.id}`);
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+    return { ok: true };
+  } catch (err) {
+    const errStr = String(err);
+    if (errStr.includes("SUB-528") || errStr.includes("SubscriptionWebSocket")) {
+      return {
+        ok: false,
+        error: "WebSocket Subscriptions permission not enabled on this app",
+      };
+    }
+    // Other errors (network, auth, etc.) — don't assume permission problem
+    return { ok: true };
+  }
+}

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -206,7 +206,9 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const warnings: string[] = [];
-      const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+      const defaultGroupPolicy = typeof resolveDefaultGroupPolicy === "function"
+        ? resolveDefaultGroupPolicy(cfg)
+        : undefined;
       const { groupPolicy } = resolveAllowlistProviderRuntimeGroupPolicy({
         providerConfigPresent: (cfg as OpenClawConfig).channels?.ringcentral !== undefined,
         groupPolicy: account.config.groupPolicy,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -631,7 +631,7 @@ async function processMessageWithPipeline(params: {
   const hasMedia = attachments.length > 0;
   const rawBody = messageText || (hasMedia ? "<media:attachment>" : "");
   if (!rawBody) {
-    logger.warn(
+    logger.debug(
       `[${account.accountId}] DROP:empty_rawBody (postId=${fullEventBody.id ?? ""} chatId=${chatId} sender=${senderId})`,
     );
     return;
@@ -772,7 +772,9 @@ async function processMessageWithPipeline(params: {
     return;
   }
 
-  const defaultGroupPolicy = resolveDefaultGroupPolicy(config);
+  const defaultGroupPolicy = typeof resolveDefaultGroupPolicy === "function"
+    ? resolveDefaultGroupPolicy(config)
+    : undefined;
   const { groupPolicy, providerMissingFallbackApplied } = resolveAllowlistProviderRuntimeGroupPolicy({
     providerConfigPresent: config.channels?.ringcentral !== undefined,
     groupPolicy: account.config.groupPolicy,
@@ -1370,7 +1372,23 @@ export async function startRingCentralMonitor(
   // ── Step 2: Create WS manager + connect + subscribe (once) ──
   logger.info(`[${account.accountId}] Starting RingCentral WebSocket subscription...`);
 
-  const mgr = await getOrCreateWsManager(account, logger);
+  let mgr: WsManager;
+  try {
+    mgr = await getOrCreateWsManager(account, logger);
+  } catch (err) {
+    const errStr = String(err);
+    if (errStr.includes("Invalid client application")) {
+      const masked = account.clientId
+        ? `${account.clientId.slice(0, 4)}...${account.clientId.slice(-4)}`
+        : "(empty)";
+      throw new Error(
+        `RingCentral clientId ${masked} is not a valid application. ` +
+        `Please verify your app at https://developers.ringcentral.com → Apps → check Client ID/Secret. ` +
+        `Original: ${errStr}`,
+      );
+    }
+    throw err;
+  }
 
   // Guard: if this WsManager already has an active subscription, skip.
   // The framework's auto-restart may call startRingCentralMonitor multiple
@@ -1421,7 +1439,25 @@ export async function startRingCentralMonitor(
   ];
 
   // Subscribe once — autoRecover will restore the subscription on reconnect
-  await mgr.wsExt.subscribe(eventFilters, handleNotification);
+  try {
+    await mgr.wsExt.subscribe(eventFilters, handleNotification);
+  } catch (err) {
+    const errStr = String(err);
+    const isSub528 = errStr.includes("SUB-528") || errStr.includes("SubscriptionWebSocket");
+    if (isSub528) {
+      // Fatal: missing WebSocket Subscriptions permission — retrying won't help
+      clearRingCentralWsManager(account.accountId);
+      throw new Error(
+        `[FATAL] RingCentral app is missing the "WebSocket Subscriptions" permission. ` +
+        `Go to https://developers.ringcentral.com → your app → Settings → "App Permissions" ` +
+        `and enable "WebSocket Subscriptions", then restart the gateway. ` +
+        `No retries will be attempted for this error.`,
+      );
+    }
+    // Non-fatal subscribe errors: clean up WsManager to avoid leaked listeners
+    clearRingCentralWsManager(account.accountId);
+    throw err;
+  }
   mgr.subscribed = true;
 
   logger.info(

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -14,7 +14,7 @@ import {
 } from "openclaw/plugin-sdk";
 
 import { resolveRingCentralAccount } from "./accounts.js";
-import { probeRingCentral } from "./api.js";
+import { checkWsSubscriptionPermission, probeRingCentral } from "./api.js";
 import type { RingCentralConfig } from "./types.js";
 
 const channel = "ringcentral" as const;
@@ -366,6 +366,27 @@ export const ringcentralOnboarding: ChannelOnboardingAdapter = {
         const probe = await probeRingCentral(resolvedAccount);
         if (probe.ok) {
           progress.stop("RingCentral credentials validated successfully!");
+
+          // Check WebSocket Subscriptions permission
+          try {
+            const wsCheckResult = await checkWsSubscriptionPermission(resolvedAccount);
+            if (!wsCheckResult.ok) {
+              await prompter.note(
+                [
+                  "WARNING: Your RingCentral app may be missing the \"WebSocket Subscriptions\" permission.",
+                  `Error: ${wsCheckResult.error}`,
+                  "",
+                  "To fix: Go to https://developers.ringcentral.com → your app → Settings →",
+                  "\"App Permissions\" and enable \"WebSocket Subscriptions\".",
+                  "",
+                  "Without this permission, the bot cannot receive real-time messages.",
+                ].join("\n"),
+                "WebSocket Permission Check",
+              );
+            }
+          } catch {
+            // Non-fatal: permission check itself may fail, don't block onboarding
+          }
         } else {
           progress.stop(`Warning: credential validation failed - ${probe.error}`);
         }


### PR DESCRIPTION
## Summary

Fixes 4 distinct error categories found in production logs (2026-02-27):

### Fix 1: Defensive plugin-sdk API compat (`resolveDefaultGroupPolicy`)
- `TypeError: resolveDefaultGroupPolicy is not a function` when plugin version > openclaw host version
- Added `typeof` guard with `undefined` fallback in `monitor.ts` and `channel.ts`

### Fix 2: Enhanced auth error for invalid clientId
- `Invalid client application: [xxx]` gave no actionable guidance
- Now shows masked clientId + link to RingCentral Developer Portal

### Fix 3: SUB-528 fatal stop + onboarding permission check
- `HTTP 403 SUB-528` (missing WebSocket Subscriptions permission) caused infinite retry loop
- First `subscribe()` failure now detects SUB-528 and throws fatal error (no channel restart)
- Onboarding wizard now probes WS permission after credential validation

### Fix 4: `DROP:empty_rawBody` log level downgrade
- Changed from WARN to DEBUG — this is expected behavior for system events/deleted messages

## Testing
- `npm run typecheck` — pass
- `npm run lint:strict` — 0 warnings, 0 errors
- `npm test` — 242/242 pass (2 pre-existing timeout failures on main)