### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-24 - File Download Path Traversal
+**Vulnerability:** File downloads via `downloadAttachment` directly used the unsanitized `attachment.name` from the RingCentral payload when saving to disk, risking path traversal (e.g., `../../../etc/passwd`).
+**Learning:** External API payloads containing filenames must never be trusted blindly. The existing `sanitizeFilename` utility was insufficient because it stripped dots entirely, which would destroy valid file extensions. A dedicated file-attachment sanitizer was needed.
+**Prevention:** Implement and use `sanitizeAttachmentFilename` for all external media downloads. This function preserves extensions while neutralizing `..` path traversal sequences and replacing invalid path characters. Ensure tests verify these specific attack patterns.

--- a/src/monitor-security.test.ts
+++ b/src/monitor-security.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { summarizeChatInfo, summarizeEvent } from "./monitor.js";
+import { summarizeChatInfo, summarizeEvent, sanitizeAttachmentFilename } from "./monitor.js";
+
+describe("sanitizeAttachmentFilename", () => {
+  it("allows safe characters", () => {
+    expect(sanitizeAttachmentFilename("file-name_123.jpg")).toBe("file-name_123.jpg");
+    expect(sanitizeAttachmentFilename("DOCUMENT.PDF")).toBe("DOCUMENT.PDF");
+  });
+
+  it("replaces unsafe characters with underscores", () => {
+    expect(sanitizeAttachmentFilename("file/name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file\\name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file*name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file?name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file\"name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file<name>.txt")).toBe("file_name_.txt");
+    expect(sanitizeAttachmentFilename("file|name.txt")).toBe("file_name.txt");
+    expect(sanitizeAttachmentFilename("file:name.txt")).toBe("file_name.txt");
+  });
+
+  it("neutralizes path traversal sequences", () => {
+    expect(sanitizeAttachmentFilename("../../../etc/passwd")).toBe("______etc_passwd");
+    expect(sanitizeAttachmentFilename("..\\..\\Windows\\System32")).toBe("____Windows_System32");
+    expect(sanitizeAttachmentFilename("file..name.txt")).toBe("file_name.txt");
+  });
+
+  it("provides fallback for empty or completely hidden names", () => {
+    expect(sanitizeAttachmentFilename("")).toBe("attachment");
+    expect(sanitizeAttachmentFilename(".")).toBe("attachment");
+    expect(sanitizeAttachmentFilename("..")).toBe("attachment");
+    expect(sanitizeAttachmentFilename("_")).toBe("attachment");
+  });
+});
 
 describe("summarizeChatInfo", () => {
   it("extracts only safe fields from chat object", () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -383,6 +383,18 @@ export function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
 
+export function sanitizeAttachmentFilename(name: string): string {
+  // Allow alphanumeric, dot, dash, underscore
+  let sanitized = name.replace(/[^a-zA-Z0-9.\-_]/g, "_");
+  // Prevent path traversal sequences
+  sanitized = sanitized.replace(/\.\.+/g, "_");
+  // Fallback if empty or hidden
+  if (!sanitized || sanitized === "." || sanitized === "_") {
+    return "attachment";
+  }
+  return sanitized;
+}
+
 /** @internal Exported for testing only. */
 export function summarizeChatInfo(chat: unknown): string {
   if (!chat || typeof chat !== "object") return "null";
@@ -1176,12 +1188,15 @@ async function downloadAttachment(
   if (!contentUri) return null;
   const maxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const downloaded = await downloadRingCentralAttachment({ account, contentUri, maxBytes });
+
+  const safeFilename = attachment.name ? sanitizeAttachmentFilename(attachment.name) : undefined;
+
   const saved = await core.channel.media.saveMediaBuffer(
     downloaded.buffer,
     downloaded.contentType ?? attachment.contentType,
     "inbound",
     maxBytes,
-    attachment.name,
+    safeFilename,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: The `downloadAttachment` function directly used the unsanitized `attachment.name` from the RingCentral payload when saving to disk (`saveMediaBuffer`). This opened the application to path traversal vulnerabilities (e.g., if the file name was maliciously crafted as `../../../etc/passwd`).

🎯 Impact: An attacker could potentially write files outside of the intended media directory, overwriting sensitive system files or planting malicious executables on the server.

🔧 Fix: Implemented a new `sanitizeAttachmentFilename` function that preserves safe characters (alphanumeric, dot, dash, underscore) and neutralizes `..` sequences to prevent traversal. Applied this sanitization to the attachment name before saving.

✅ Verification: 
- Added comprehensive unit tests in `src/monitor-security.test.ts` to ensure path traversal sequences and invalid characters are correctly neutralized.
- Ran `pnpm test` and `pnpm lint` to verify all tests pass and there are no linting errors.

---
*PR created automatically by Jules for task [6863516228924341562](https://jules.google.com/task/6863516228924341562) started by @danbao*