### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in attachment downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-03 - Path Traversal in Attachment Downloads
+**Vulnerability:** The `downloadAttachment` function in `src/monitor.ts` passes the raw `attachment.name` directly to `core.channel.media.saveMediaBuffer` without sanitization, allowing potential path traversal if the filename contains `../` sequences.
+**Learning:** External attachment filenames should never be trusted as safe file system names. They can be spoofed by attackers.
+**Prevention:** Implemented and applied a `sanitizeAttachmentFilename` function that explicitly removes `..` sequences and restricts characters to an allowlist (alphanumeric, dash, underscore, and dot).

--- a/src/monitor-security.test.ts
+++ b/src/monitor-security.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { summarizeChatInfo, summarizeEvent } from "./monitor.js";
+import { summarizeChatInfo, summarizeEvent, sanitizeAttachmentFilename } from "./monitor.js";
+
+describe("sanitizeAttachmentFilename", () => {
+  it("removes unsafe characters but keeps dots and safe characters", () => {
+    expect(sanitizeAttachmentFilename("my_file.txt")).toBe("my_file.txt");
+    expect(sanitizeAttachmentFilename("my-file-123.jpg")).toBe("my-file-123.jpg");
+    expect(sanitizeAttachmentFilename("file/with\\slashes.png")).toBe("file_with_slashes.png");
+    expect(sanitizeAttachmentFilename("file?name*.pdf")).toBe("file_name_.pdf");
+  });
+
+  it("prevents path traversal by neutralizing .. sequences", () => {
+    expect(sanitizeAttachmentFilename("../../../etc/passwd")).toBe("______etc_passwd");
+    expect(sanitizeAttachmentFilename("..\\..\\..\\etc\\passwd")).toBe("______etc_passwd");
+    expect(sanitizeAttachmentFilename("my..file.txt")).toBe("my_file.txt");
+    expect(sanitizeAttachmentFilename("...")).toBe("_");
+    expect(sanitizeAttachmentFilename("..")).toBe("_");
+  });
+});
 
 describe("summarizeChatInfo", () => {
   it("extracts only safe fields from chat object", () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -383,6 +383,13 @@ export function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
 
+export function sanitizeAttachmentFilename(name: string): string {
+  // Prevent path traversal by removing ".." sequences first
+  const noTraversal = name.replace(/\.{2,}/g, "_");
+  // Replace unsafe chars with underscore. Allow dots for file extensions.
+  return noTraversal.replace(/[^a-zA-Z0-9-_.]/g, "_");
+}
+
 /** @internal Exported for testing only. */
 export function summarizeChatInfo(chat: unknown): string {
   if (!chat || typeof chat !== "object") return "null";
@@ -1176,12 +1183,13 @@ async function downloadAttachment(
   if (!contentUri) return null;
   const maxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const downloaded = await downloadRingCentralAttachment({ account, contentUri, maxBytes });
+  const safeName = attachment.name ? sanitizeAttachmentFilename(attachment.name) : undefined;
   const saved = await core.channel.media.saveMediaBuffer(
     downloaded.buffer,
     downloaded.contentType ?? attachment.contentType,
     "inbound",
     maxBytes,
-    attachment.name,
+    safeName,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `downloadAttachment` function in `src/monitor.ts` passes the raw `attachment.name` directly to `core.channel.media.saveMediaBuffer` without sanitization. If an attacker spoofs a filename containing `../` sequences, it could lead to path traversal vulnerabilities and unauthorized file writes.
🎯 Impact: An attacker could potentially write files outside of the intended media storage directory, leading to data overwrite, arbitrary code execution (if a script file is overwritten), or denial of service.
🔧 Fix: Implemented a robust `sanitizeAttachmentFilename` function that explicitly removes `..` sequences and restricts characters to a safe allowlist (alphanumeric, dash, underscore, and dot). This function is now applied to `attachment.name` before passing it to `saveMediaBuffer`.
✅ Verification: Ran `pnpm test` and `pnpm lint`. Added comprehensive tests in `src/monitor-security.test.ts` to ensure path traversal sequences and unsafe characters are neutralized properly.

---
*PR created automatically by Jules for task [14292684549309733620](https://jules.google.com/task/14292684549309733620) started by @danbao*