### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-02-24 - Fix path traversal in file download
+
+**Vulnerability:** The application was passing unsanitized attachment filenames straight from the RingCentral API into `core.channel.media.saveMediaBuffer`. This exposed a path traversal vulnerability because an attacker could send an attachment with a manipulated name like `../../../etc/passwd` to write files to arbitrary locations in the filesystem.
+**Learning:** External attachment filenames (`attachment.name`) obtained from RingCentral are not inherently safe and should always be explicitly sanitized using the dedicated `sanitizeAttachmentFilename` helper before being used in file system operations to prevent path traversal attacks.
+**Prevention:** Always validate and sanitize user-provided file names before writing to the local filesystem. Specifically, use an allowlist-based approach (alphanumeric, dot, dash, underscore) and strictly remove/neutralize any directory traversal sequences like `..` before utilizing the filename.

--- a/src/monitor-security.test.ts
+++ b/src/monitor-security.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { summarizeChatInfo, summarizeEvent } from "./monitor.js";
+import { summarizeChatInfo, summarizeEvent, sanitizeAttachmentFilename } from "./monitor.js";
+
+describe("sanitizeAttachmentFilename", () => {
+  it("keeps normal filenames intact", () => {
+    expect(sanitizeAttachmentFilename("hello.txt")).toBe("hello.txt");
+    expect(sanitizeAttachmentFilename("image-1_2.png")).toBe("image-1_2.png");
+  });
+
+  it("replaces spaces and unsafe characters with underscores", () => {
+    expect(sanitizeAttachmentFilename("hello world.txt")).toBe("hello_world.txt");
+    expect(sanitizeAttachmentFilename("foo!@#bar.doc")).toBe("foo_bar.doc");
+    expect(sanitizeAttachmentFilename("a/b\\c.pdf")).toBe("a_b_c.pdf");
+  });
+
+  it("neutralizes path traversal sequences", () => {
+    expect(sanitizeAttachmentFilename("../../../etc/passwd")).toBe("etc_passwd");
+    expect(sanitizeAttachmentFilename("..\\..\\windows\\system32")).toBe("windows_system32");
+    expect(sanitizeAttachmentFilename("a/b/../../../c.txt")).toBe("a_b_c.txt");
+  });
+
+  it("handles empty or null inputs", () => {
+    expect(sanitizeAttachmentFilename("")).toBeUndefined();
+    expect(sanitizeAttachmentFilename(undefined)).toBeUndefined();
+  });
+
+  it("provides fallback if name becomes empty after sanitization", () => {
+    expect(sanitizeAttachmentFilename("///")).toBe("attachment");
+    expect(sanitizeAttachmentFilename("...")).toBe("attachment");
+    expect(sanitizeAttachmentFilename("!@#")).toBe("attachment");
+  });
+});
 
 describe("summarizeChatInfo", () => {
   it("extracts only safe fields from chat object", () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -383,6 +383,29 @@ export function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
 
+export function sanitizeAttachmentFilename(name?: string): string | undefined {
+  if (!name) return undefined;
+  // Replace anything that is not alphanumeric, dot, dash, or underscore.
+  let safeName = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+  // Prevent directory traversal sequences (e.g., "..", "...", etc.)
+  safeName = safeName.replace(/\.{2,}/g, ".");
+
+  // Neutralize `/../` replacements like `_._._` or `_._`
+  safeName = safeName.replace(/_\._/g, "_");
+  safeName = safeName.replace(/(\._)+/g, "_");
+  safeName = safeName.replace(/(_\.)+/g, "_");
+
+  // Condense multiple underscores
+  safeName = safeName.replace(/_+/g, "_");
+
+  // Remove leading or trailing non-alphanumeric chars
+  safeName = safeName.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, "");
+
+  if (!safeName) return "attachment"; // Fallback if name becomes empty after sanitization
+  return safeName;
+}
+
 /** @internal Exported for testing only. */
 export function summarizeChatInfo(chat: unknown): string {
   if (!chat || typeof chat !== "object") return "null";
@@ -1181,7 +1204,7 @@ async function downloadAttachment(
     downloaded.contentType ?? attachment.contentType,
     "inbound",
     maxBytes,
-    attachment.name,
+    sanitizeAttachmentFilename(attachment.name),
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized attachment filenames provided via the RingCentral API (`attachment.name`) were being passed directly to `core.channel.media.saveMediaBuffer()`. This exposed a critical path traversal vulnerability where an attacker could upload an attachment with a maliciously crafted name like `../../../etc/passwd` to write files to arbitrary locations in the filesystem.
🎯 **Impact:** Unauthorized file write access, leading to potential Remote Code Execution (RCE) or system compromise by overwriting critical system or application files.
🔧 **Fix:** Introduced the `sanitizeAttachmentFilename` function in `src/monitor.ts`. This utility explicitly enforces an allowlist (alphanumeric, dot, dash, underscore) and aggressively removes directory traversal sequences (e.g., `..`, `_\._`, etc.). The sanitized name is then safely passed to the storage mechanism. 
✅ **Verification:** Added extensive unit tests in `src/monitor-security.test.ts` to verify path traversal sequences are successfully neutralized, and executed `pnpm test` and `pnpm lint` to ensure correct functionality.

---
*PR created automatically by Jules for task [5298719600437202617](https://jules.google.com/task/5298719600437202617) started by @danbao*