### PR TITLE
fix: support target param in resolveChannelId for read action

### DIFF
--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -107,9 +107,9 @@ function readNumberParam(
 }
 
 function resolveChannelId(params: Record<string, unknown>): string {
-  const chatId = readStringParam(params, "chatId") ?? readStringParam(params, "channelId");
+  const chatId = readStringParam(params, "chatId") ?? readStringParam(params, "channelId") ?? readStringParam(params, "target");
   if (!chatId) {
-    throw new Error("chatId or channelId is required");
+    throw new Error("chatId, channelId, or target is required");
   }
   const normalized = normalizeRingCentralTarget(chatId);
   if (!normalized) {


### PR DESCRIPTION
## Summary

Fix `resolveChannelId` to also accept the `target` parameter, allowing the `read` action (and all other actions using `resolveChannelId`) to work when called via the OpenClaw message tool with `target` instead of `chatId`/`channelId`.

## Changes

- Added `target` as a fallback in `resolveChannelId` after `chatId` and `channelId`
- Updated error message to reflect the three accepted parameters

Closes #96