### PR TITLE
🛡️ Sentinel: [HIGH] Fix outgoing file download path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** File downloads via `downloadAttachment` directly used the unsanitized `attachment.name` from the RingCentral payload when saving to disk, risking path traversal (e.g., `../../../etc/passwd`).
 **Learning:** External API payloads containing filenames must never be trusted blindly. The existing `sanitizeFilename` utility was insufficient because it stripped dots entirely, which would destroy valid file extensions. A dedicated file-attachment sanitizer was needed.
 **Prevention:** Implement and use `sanitizeAttachmentFilename` for all external media downloads. This function preserves extensions while neutralizing `..` path traversal sequences and replacing invalid path characters. Ensure tests verify these specific attack patterns.
+
+## 2026-03-03 - Outgoing File Download Path Traversal
+**Vulnerability:** When downloading an external media URL to attach to a RingCentral outgoing message, the code relied entirely on the potentially malicious `filename` returned by the external fetch. If an attacker controlled the URL and served a file with a `Content-Disposition` containing path traversal characters, passing this unsanitized filename directly to the `uploadRingCentralAttachment` API could pose a risk to the RingCentral server or intermediary systems if they naively use the filename.
+**Learning:** We must sanitize not only the filenames of incoming attachments but also the filenames fetched from external resources before they are pushed out to third-party APIs. It's important to never trust external data, regardless of the direction it's flowing.
+**Prevention:** Always wrap fetched filenames with `sanitizeAttachmentFilename` before handing them off to `uploadRingCentralAttachment`.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,7 +34,7 @@ import {
   getRingCentralChat,
 } from "./api.js";
 import { getRingCentralRuntime } from "./runtime.js";
-import { startRingCentralMonitor, clearRingCentralWsManager } from "./monitor.js";
+import { startRingCentralMonitor, clearRingCentralWsManager, sanitizeAttachmentFilename } from "./monitor.js";
 import {
   normalizeRingCentralTarget,
   isRingCentralChatTarget,
@@ -564,7 +564,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       const upload = await uploadRingCentralAttachment({
         account,
         chatId: to,
-        filename: loaded.filename ?? "attachment",
+        filename: sanitizeAttachmentFilename(loaded.filename ?? "attachment"),
         buffer: loaded.buffer,
         contentType: loaded.contentType,
       });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1337,7 +1337,7 @@ async function deliverRingCentralReply(params: {
         const upload = await uploadRingCentralAttachment({
           account,
           chatId,
-          filename: loaded.filename ?? "attachment",
+          filename: sanitizeAttachmentFilename(loaded.filename ?? "attachment"),
           buffer: loaded.buffer,
           contentType: loaded.contentType,
         });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When fetching external media to send as an outgoing attachment in RingCentral, the system used the `filename` provided by the external resource (via `Content-Disposition`) directly without sanitization. An attacker controlling the external URL could serve a file with path traversal characters (like `../../`), potentially exploiting downstream systems or the API itself.
🎯 Impact: Could allow an attacker to execute path traversal attacks against the RingCentral API or intermediary storage systems that handle the attachment filename naively.
🔧 Fix: Wrapped the `loaded.filename` (defaulting to `"attachment"`) with the existing `sanitizeAttachmentFilename` utility in both `src/monitor.ts` and `src/channel.ts` before calling `uploadRingCentralAttachment`.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. Verified that `loaded.filename` is explicitly sanitized in all `uploadRingCentralAttachment` call sites.

---
*PR created automatically by Jules for task [1061524240623242087](https://jules.google.com/task/1061524240623242087) started by @danbao*