### PR TITLE
🛡️ Sentinel: [HIGH] Fix file upload path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** File downloads via `downloadAttachment` directly used the unsanitized `attachment.name` from the RingCentral payload when saving to disk, risking path traversal (e.g., `../../../etc/passwd`).
 **Learning:** External API payloads containing filenames must never be trusted blindly. The existing `sanitizeFilename` utility was insufficient because it stripped dots entirely, which would destroy valid file extensions. A dedicated file-attachment sanitizer was needed.
 **Prevention:** Implement and use `sanitizeAttachmentFilename` for all external media downloads. This function preserves extensions while neutralizing `..` path traversal sequences and replacing invalid path characters. Ensure tests verify these specific attack patterns.
+
+## 2026-03-08 - File Upload Path Traversal
+**Vulnerability:** External media filenames (`loaded.filename`) fetched for outgoing attachments were explicitly passed to `uploadRingCentralAttachment` without sanitization, trusting the original external filename.
+**Learning:** Similarly to downloads, filenames of external origin for uploads must be sanitized to prevent malicious file naming or path traversal on the system where the upload is eventually saved.
+**Prevention:** Always use `sanitizeAttachmentFilename` to sanitize `loaded.filename` before passing it to internal upload utilities.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,7 +34,7 @@ import {
   getRingCentralChat,
 } from "./api.js";
 import { getRingCentralRuntime } from "./runtime.js";
-import { startRingCentralMonitor, clearRingCentralWsManager } from "./monitor.js";
+import { startRingCentralMonitor, clearRingCentralWsManager, sanitizeAttachmentFilename } from "./monitor.js";
 import {
   normalizeRingCentralTarget,
   isRingCentralChatTarget,
@@ -564,7 +564,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       const upload = await uploadRingCentralAttachment({
         account,
         chatId: to,
-        filename: loaded.filename ?? "attachment",
+        filename: loaded.filename ? sanitizeAttachmentFilename(loaded.filename) : "attachment",
         buffer: loaded.buffer,
         contentType: loaded.contentType,
       });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1337,7 +1337,7 @@ async function deliverRingCentralReply(params: {
         const upload = await uploadRingCentralAttachment({
           account,
           chatId,
-          filename: loaded.filename ?? "attachment",
+          filename: loaded.filename ? sanitizeAttachmentFilename(loaded.filename) : "attachment",
           buffer: loaded.buffer,
           contentType: loaded.contentType,
         });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External media filenames (`loaded.filename`) fetched for outgoing attachments were explicitly passed to `uploadRingCentralAttachment` without any sanitization. This trusted external payloads, posing a risk of path traversal or malicious file naming.
🎯 Impact: An attacker or malicious external payload could provide a filename like `../../../etc/passwd` to potentially cause path traversal on the system where the upload is eventually saved.
🔧 Fix: Wrapped the `loaded.filename` passed to `uploadRingCentralAttachment` with the existing `sanitizeAttachmentFilename` utility function in both `src/monitor.ts` and `src/channel.ts`. If no filename is provided, it falls back to `"attachment"`.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. Verified logic locally.

---
*PR created automatically by Jules for task [2134553072888022107](https://jules.google.com/task/2134553072888022107) started by @danbao*