### PR TITLE
🛡️ Sentinel: [HIGH] Fix Outgoing Attachment Path Traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** File downloads via `downloadAttachment` directly used the unsanitized `attachment.name` from the RingCentral payload when saving to disk, risking path traversal (e.g., `../../../etc/passwd`).
 **Learning:** External API payloads containing filenames must never be trusted blindly. The existing `sanitizeFilename` utility was insufficient because it stripped dots entirely, which would destroy valid file extensions. A dedicated file-attachment sanitizer was needed.
 **Prevention:** Implement and use `sanitizeAttachmentFilename` for all external media downloads. This function preserves extensions while neutralizing `..` path traversal sequences and replacing invalid path characters. Ensure tests verify these specific attack patterns.
+
+## 2026-03-10 - Outgoing File Attachment Path Traversal
+**Vulnerability:** External media filenames (`loaded.filename`) fetched for outgoing attachments were directly passed unsanitized to `uploadRingCentralAttachment` in both `src/channel.ts` and `src/monitor.ts`, which could lead to path traversal or malicious file naming.
+**Learning:** Similar to incoming attachments, outgoing media retrieved from external sources (like URLs provided in messages) can contain malicious filenames in headers (e.g., `Content-Disposition`). We must sanitize these filenames before passing them to the RingCentral API.
+**Prevention:** Always use `sanitizeAttachmentFilename` on `loaded.filename` or any external filename before uploading attachments via `uploadRingCentralAttachment`.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,7 +34,7 @@ import {
   getRingCentralChat,
 } from "./api.js";
 import { getRingCentralRuntime } from "./runtime.js";
-import { startRingCentralMonitor, clearRingCentralWsManager } from "./monitor.js";
+import { startRingCentralMonitor, clearRingCentralWsManager, sanitizeAttachmentFilename } from "./monitor.js";
 import {
   normalizeRingCentralTarget,
   isRingCentralChatTarget,
@@ -561,10 +561,11 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedRingCentralAccount> = {
       const loaded = await runtime.channel.media.fetchRemoteMedia(mediaUrl, {
         maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
       });
+      const rawFilename = loaded.filename ?? "attachment";
       const upload = await uploadRingCentralAttachment({
         account,
         chatId: to,
-        filename: loaded.filename ?? "attachment",
+        filename: sanitizeAttachmentFilename(rawFilename),
         buffer: loaded.buffer,
         contentType: loaded.contentType,
       });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1334,10 +1334,11 @@ async function deliverRingCentralReply(params: {
         const loaded = await core.channel.media.fetchRemoteMedia(mediaUrl, {
           maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
         });
+        const rawFilename = loaded.filename ?? "attachment";
         const upload = await uploadRingCentralAttachment({
           account,
           chatId,
-          filename: loaded.filename ?? "attachment",
+          filename: sanitizeAttachmentFilename(rawFilename),
           buffer: loaded.buffer,
           contentType: loaded.contentType,
         });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External media filenames (`loaded.filename`) fetched for outgoing attachments were directly passed unsanitized to `uploadRingCentralAttachment` in both `src/channel.ts` and `src/monitor.ts`. This could lead to path traversal or malicious file naming.
🎯 Impact: An attacker providing a malicious media URL could supply a crafted filename (e.g., via `Content-Disposition`) containing path traversal sequences or restricted characters, which would then be sent blindly to the RingCentral API. 
🔧 Fix: Wrapped the fallback `loaded.filename` string with `sanitizeAttachmentFilename` prior to invoking `uploadRingCentralAttachment`.
✅ Verification: Ran `pnpm lint` and `pnpm test` locally to ensure no regressions were introduced. Also successfully requested code review.

---
*PR created automatically by Jules for task [4053722815650889746](https://jules.google.com/task/4053722815650889746) started by @danbao*