### PR TITLE
Security: Fix 6 issues from security team review

### DIFF
--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { getEnabledActions, handleAction, type ActionName } from "./actions-adapter.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getEnabledActions, handleAction, __testing, type ActionName } from "./actions-adapter.js";
 import * as actions from "./actions.js";
 
 vi.mock("./actions.js", () => ({
@@ -26,6 +26,11 @@ vi.mock("./actions.js", () => ({
 
 const mockClient = {} as any;
 
+beforeEach(() => {
+  __testing.pendingActions.clear();
+  vi.clearAllMocks();
+});
+
 describe("getEnabledActions", () => {
   it("returns all actions by default", () => {
     const all = getEnabledActions();
@@ -34,7 +39,8 @@ describe("getEnabledActions", () => {
     expect(all).toContain("create-task");
     expect(all).toContain("create-event");
     expect(all).toContain("create-note");
-    expect(all.length).toBe(19);
+    expect(all).toContain("confirm-action");
+    expect(all.length).toBe(20);
   });
 
   it("excludes messages when disabled", () => {
@@ -81,13 +87,18 @@ describe("handleAction", () => {
     expect(actions.actionReadMessages).toHaveBeenCalledWith(mockClient, "c1", 10);
   });
 
-  it("routes edit-message", async () => {
-    await handleAction(mockClient, "edit-message", { chatId: "c1", postId: "p1", text: "updated" });
+  it("routes edit-message (requires confirmation)", async () => {
+    const result = await handleAction(mockClient, "edit-message", { chatId: "c1", postId: "p1", text: "updated" }) as any;
+    expect(result.requiresConfirmation).toBe(true);
+    // Confirm and verify execution
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionEditMessage).toHaveBeenCalledWith(mockClient, "c1", "p1", "updated");
   });
 
-  it("routes delete-message", async () => {
-    await handleAction(mockClient, "delete-message", { chatId: "c1", postId: "p1" });
+  it("routes delete-message (requires confirmation)", async () => {
+    const result = await handleAction(mockClient, "delete-message", { chatId: "c1", postId: "p1" }) as any;
+    expect(result.requiresConfirmation).toBe(true);
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteMessage).toHaveBeenCalledWith(mockClient, "c1", "p1");
   });
 
@@ -120,7 +131,9 @@ describe("handleAction", () => {
     await handleAction(mockClient, "send-message", { chat_id: "c2", message: "yo" });
     expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "c2", "yo");
 
-    await handleAction(mockClient, "delete-message", { chat_id: "c2", messageId: "m1" });
+    const result = await handleAction(mockClient, "delete-message", { chat_id: "c2", messageId: "m1" }) as any;
+    expect(result.requiresConfirmation).toBe(true);
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteMessage).toHaveBeenCalledWith(mockClient, "c2", "m1");
   });
 
@@ -129,19 +142,122 @@ describe("handleAction", () => {
     expect(actions.actionCreateTask).toHaveBeenCalledWith(mockClient, "c1", "Task via title", undefined);
   });
 
-  it("supports id alias for taskId/eventId/noteId", async () => {
-    await handleAction(mockClient, "delete-task", { id: "t99" });
+  it("supports id alias for taskId/eventId/noteId (via confirmation)", async () => {
+    let result: any;
+
+    result = await handleAction(mockClient, "delete-task", { id: "t99" });
+    expect(result.requiresConfirmation).toBe(true);
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteTask).toHaveBeenCalledWith(mockClient, "t99");
 
-    await handleAction(mockClient, "delete-event", { id: "e99" });
+    result = await handleAction(mockClient, "delete-event", { id: "e99" });
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteEvent).toHaveBeenCalledWith(mockClient, "e99");
 
-    await handleAction(mockClient, "delete-note", { id: "n99" });
+    result = await handleAction(mockClient, "delete-note", { id: "n99" });
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteNote).toHaveBeenCalledWith(mockClient, "n99");
   });
 
   it("returns error for unknown action", async () => {
     const result = await handleAction(mockClient, "unknown-action" as ActionName, {});
     expect(result).toEqual({ success: false, error: "Unknown action: unknown-action" });
+  });
+
+  describe("chat scope validation", () => {
+    it("blocks chat-scoped action when chatId differs from sessionChatId", async () => {
+      const result = await handleAction(
+        mockClient,
+        "send-message",
+        { chatId: "evil-chat", text: "hi" },
+        "session-chat",
+      );
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("Action scope violation"),
+      });
+      expect(actions.actionSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("allows chat-scoped action when chatId matches sessionChatId", async () => {
+      await handleAction(
+        mockClient,
+        "send-message",
+        { chatId: "session-chat", text: "hi" },
+        "session-chat",
+      );
+      expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "session-chat", "hi");
+    });
+
+    it("allows action when no sessionChatId is provided", async () => {
+      await handleAction(mockClient, "send-message", { chatId: "any-chat", text: "hi" });
+      expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "any-chat", "hi");
+    });
+
+    it("allows non-chat-scoped actions with different chatId", async () => {
+      const result = await handleAction(
+        mockClient,
+        "delete-task",
+        { id: "t1" },
+        "session-chat",
+      ) as any;
+      // delete-task is a protected action, so it returns confirmation instead
+      expect(result.requiresConfirmation).toBe(true);
+    });
+  });
+
+  describe("confirmation flow", () => {
+    it("returns confirmation for protected actions", async () => {
+      const result = await handleAction(mockClient, "delete-note", { noteId: "n1" }) as any;
+      expect(result.requiresConfirmation).toBe(true);
+      expect(result.confirmationId).toBeTruthy();
+      expect(result.summary).toContain("delete-note");
+      expect(result.summary).toContain("n1");
+      expect(actions.actionDeleteNote).not.toHaveBeenCalled();
+    });
+
+    it("executes action after confirmation", async () => {
+      const result = await handleAction(mockClient, "delete-note", { noteId: "n1" }) as any;
+      const nonce = result.confirmationId;
+
+      await handleAction(mockClient, "confirm-action", { nonce });
+      expect(actions.actionDeleteNote).toHaveBeenCalledWith(mockClient, "n1");
+    });
+
+    it("rejects invalid confirmation nonce", async () => {
+      const result = await handleAction(mockClient, "confirm-action", { nonce: "bad-nonce" }) as any;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid or expired");
+    });
+
+    it("rejects reuse of confirmation nonce", async () => {
+      const result = await handleAction(mockClient, "delete-task", { id: "t1" }) as any;
+      const nonce = result.confirmationId;
+
+      await handleAction(mockClient, "confirm-action", { nonce });
+      const reuse = await handleAction(mockClient, "confirm-action", { nonce }) as any;
+      expect(reuse.success).toBe(false);
+      expect(reuse.error).toContain("Invalid or expired");
+    });
+
+    it("does not require confirmation for non-protected actions", async () => {
+      await handleAction(mockClient, "send-message", { chatId: "c1", text: "hi" });
+      expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "c1", "hi");
+    });
+
+    it("does not require confirmation for read actions", async () => {
+      await handleAction(mockClient, "list-tasks", { chatId: "c1" });
+      expect(actions.actionListTasks).toHaveBeenCalledWith(mockClient, "c1");
+    });
+
+    it("requires confirmation for edit-message", async () => {
+      const result = await handleAction(mockClient, "edit-message", { chatId: "c1", postId: "p1", text: "new" }) as any;
+      expect(result.requiresConfirmation).toBe(true);
+    });
+
+    it("requires confirmation for update-event", async () => {
+      const result = await handleAction(mockClient, "update-event", { eventId: "e1", title: "new" }) as any;
+      expect(result.requiresConfirmation).toBe(true);
+    });
   });
 });

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -1,7 +1,57 @@
 // OpenClaw action protocol adapter — maps agent tool calls to actions.ts.
 
+import { randomBytes } from "node:crypto";
 import type { RingCentralClient } from "./client.js";
 import * as actions from "./actions.js";
+
+const CHAT_SCOPED_ACTIONS = new Set<ActionName>([
+  "send-message",
+  "read-messages",
+  "edit-message",
+  "delete-message",
+  "channel-info",
+  "list-tasks",
+  "create-task",
+  "list-notes",
+  "create-note",
+]);
+
+const PROTECTED_ACTIONS = new Set<ActionName>([
+  "delete-message",
+  "delete-task",
+  "delete-event",
+  "delete-note",
+  "update-task",
+  "update-event",
+  "update-note",
+  "edit-message",
+]);
+
+const PENDING_ACTION_TTL_MS = 2 * 60 * 1000; // 2 minutes
+
+interface PendingAction {
+  action: ActionName;
+  params: Record<string, unknown>;
+  expiresAt: number;
+}
+
+const pendingActions = new Map<string, PendingAction>();
+
+function cleanExpiredPendingActions(): void {
+  const now = Date.now();
+  for (const [nonce, pending] of pendingActions) {
+    if (now >= pending.expiresAt) pendingActions.delete(nonce);
+  }
+}
+
+function generateNonce(): string {
+  return randomBytes(16).toString("hex");
+}
+
+function buildConfirmationSummary(action: ActionName, params: Record<string, unknown>): string {
+  const id = String(params.taskId ?? params.eventId ?? params.noteId ?? params.postId ?? params.id ?? params.messageId ?? "");
+  return `Confirm ${action}${id ? ` (id: ${id})` : ""}?`;
+}
 
 export type ActionName =
   | "send-message"
@@ -22,7 +72,8 @@ export type ActionName =
   | "create-note"
   | "update-note"
   | "delete-note"
-  | "publish-note";
+  | "publish-note"
+  | "confirm-action";
 
 export interface ActionConfig {
   messages?: boolean;
@@ -49,10 +100,56 @@ export function getEnabledActions(config: ActionConfig = {}): ActionName[] {
   if (config.notes !== false) {
     all.push("list-notes", "create-note", "update-note", "delete-note", "publish-note");
   }
+  all.push("confirm-action");
   return all;
 }
 
+// Exported for testing
+export const __testing = { pendingActions, PROTECTED_ACTIONS };
+
 export async function handleAction(
+  client: RingCentralClient,
+  action: ActionName,
+  params: Record<string, unknown>,
+  sessionChatId?: string,
+): Promise<unknown> {
+  const chatId = String(params.chatId ?? params.chat_id ?? "");
+  const postId = String(params.postId ?? params.post_id ?? params.messageId ?? "");
+  const text = String(params.text ?? params.message ?? "");
+
+  // Scope check: ensure chat-scoped actions target the active session's chat
+  if (sessionChatId && CHAT_SCOPED_ACTIONS.has(action) && chatId && chatId !== sessionChatId) {
+    return { success: false, error: `Action scope violation: chatId "${chatId}" does not match current session chat` };
+  }
+
+  // Handle confirmation flow for protected actions
+  if (action === "confirm-action") {
+    const nonce = String(params.nonce ?? params.confirmationId ?? "");
+    cleanExpiredPendingActions();
+    const pending = pendingActions.get(nonce);
+    if (!pending) {
+      return { success: false, error: "Invalid or expired confirmation. Please retry the original action." };
+    }
+    pendingActions.delete(nonce);
+    return executeAction(client, pending.action, pending.params);
+  }
+
+  if (PROTECTED_ACTIONS.has(action)) {
+    cleanExpiredPendingActions();
+    const nonce = generateNonce();
+    pendingActions.set(nonce, { action, params: { ...params }, expiresAt: Date.now() + PENDING_ACTION_TTL_MS });
+    return {
+      requiresConfirmation: true,
+      confirmationId: nonce,
+      summary: buildConfirmationSummary(action, params),
+      action,
+    };
+  }
+
+  return executeAction(client, action, params);
+}
+
+async function executeAction(
   client: RingCentralClient,
   action: ActionName,
   params: Record<string, unknown>,

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -38,7 +38,7 @@ describe("getAccessToken", () => {
 
   it("throws on HTTP error", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ error: "bad" }, 401));
-    await expect(getAccessToken(...args)).rejects.toThrow("Token request failed HTTP 401");
+    await expect(getAccessToken(...args)).rejects.toThrow("Token request failed (HTTP 401)");
   });
 
   it("invalidateToken forces re-fetch", async () => {
@@ -88,7 +88,7 @@ describe("getWSToken", () => {
   it("throws on other HTTP errors", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ error: "server" }, 500));
     await expect(getWSToken("https://platform.ringcentral.com", "tok")).rejects.toThrow(
-      "WS token request failed HTTP 500",
+      "WS token request failed (HTTP 500)",
     );
   });
 });
@@ -105,7 +105,7 @@ describe("getBotWSToken", () => {
   it("throws on HTTP error", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ error: "denied" }, 403));
     await expect(getBotWSToken("https://platform.ringcentral.com", "bot-tok")).rejects.toThrow(
-      "Bot WS token request failed HTTP 403",
+      "Bot WS token request failed (HTTP 403)",
     );
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -55,8 +55,7 @@ async function refreshToken(
     body: body.toString(),
   });
   if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Token request failed HTTP ${resp.status}: ${text}`);
+    throw new Error(`Token request failed (HTTP ${resp.status}). Check credentials and server URL.`);
   }
   const data = (await resp.json()) as TokenResponse;
   return {
@@ -79,8 +78,7 @@ export async function getWSToken(
     throw new Error("Token expired, invalidated for retry");
   }
   if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`WS token request failed HTTP ${resp.status}: ${text}`);
+    throw new Error(`WS token request failed (HTTP ${resp.status}). Check access token validity.`);
   }
   return (await resp.json()) as WSTokenResponse;
 }
@@ -95,8 +93,7 @@ export async function getBotWSToken(
     headers: { Authorization: `Bearer ${botToken}` },
   });
   if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Bot WS token request failed HTTP ${resp.status}: ${text}`);
+    throw new Error(`Bot WS token request failed (HTTP ${resp.status}). Check bot token validity.`);
   }
   return (await resp.json()) as WSTokenResponse;
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -24,6 +24,7 @@ import { buildDmTarget, buildGroupTarget, extractChatId, normalizeTarget, RC_PRE
 import type { RingCentralConfig, ResolvedAccount } from "./types.js";
 import { getEnabledActions, handleAction, type ActionName } from "./actions-adapter.js";
 import { getRingCentralRuntime } from "./runtime.js";
+import { setOwnerId, getOwnerId } from "./identity.js";
 
 function getRcConfig(cfg: OpenClawConfig): RingCentralConfig {
   const channels = (cfg as Record<string, unknown>).channels as Record<string, unknown> | undefined;
@@ -81,6 +82,14 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
           const ext = await botClient.getExtensionInfo();
           botExtensionId = String(ext.id);
         } catch { /* continue without */ }
+      }
+
+      // Cache the private app owner identity for Self Only mode verification
+      if (hasPrivateApp(account)) {
+        try {
+          const ownerExt = await readClient.getExtensionInfo();
+          setOwnerId(String(ownerExt.id));
+        } catch { /* continue without — selfOnly will reject all if not cached */ }
       }
 
       setStatus({ state: "connecting" } as any);
@@ -190,7 +199,8 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
           )
         : createBotClient(account.server, account.botToken);
 
-      const result = await handleAction(client, ctx.action as ActionName, ctx.params);
+      const sessionChatId = (ctx as any).toolContext?.currentChannelId as string | undefined;
+      const result = await handleAction(client, ctx.action as ActionName, ctx.params, sessionChatId);
       return { content: result, details: result } as any;
     },
   },
@@ -212,6 +222,14 @@ async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   const chatId = post.groupId;
   const text = post.text ?? "";
   const senderId = post.creatorId;
+
+  // Self Only mode: only process messages from the cached private app owner
+  if (account.config.selfOnly) {
+    const ownerId = getOwnerId();
+    if (!ownerId || senderId !== ownerId) {
+      return;
+    }
+  }
 
   // Determine chat type
   let chatType: "direct" | "group" | "channel" = "direct";

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setOwnerId, getOwnerId, clearOwnerId } from "./identity.js";
+
+describe("identity", () => {
+  beforeEach(() => {
+    clearOwnerId();
+  });
+
+  it("returns null when not set", () => {
+    expect(getOwnerId()).toBeNull();
+  });
+
+  it("returns the cached owner id after set", () => {
+    setOwnerId("12345");
+    expect(getOwnerId()).toBe("12345");
+  });
+
+  it("clears the cached owner id", () => {
+    setOwnerId("12345");
+    clearOwnerId();
+    expect(getOwnerId()).toBeNull();
+  });
+
+  it("overwrites previous value", () => {
+    setOwnerId("111");
+    setOwnerId("222");
+    expect(getOwnerId()).toBe("222");
+  });
+});

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,0 +1,16 @@
+// Cached owner identity for Self Only mode verification.
+// Set once at startup via the private app's extension/~ endpoint.
+
+let cachedOwnerId: string | null = null;
+
+export function setOwnerId(id: string): void {
+  cachedOwnerId = id;
+}
+
+export function getOwnerId(): string | null {
+  return cachedOwnerId;
+}
+
+export function clearOwnerId(): void {
+  cachedOwnerId = null;
+}

--- a/src/markdown.test.ts
+++ b/src/markdown.test.ts
@@ -24,6 +24,36 @@ describe("markdownToMiniMarkdown", () => {
     expect(markdownToMiniMarkdown("![alt](https://img.png)")).toBe("https://img.png");
   });
 
+  it("strips javascript: image URIs and falls back to alt text", () => {
+    expect(markdownToMiniMarkdown("![click me](javascript:void)")).toBe("click me");
+  });
+
+  it("strips data: image URIs", () => {
+    expect(markdownToMiniMarkdown("![](data:text/html,payload)")).toBe("");
+  });
+
+  it("strips file: image URIs", () => {
+    expect(markdownToMiniMarkdown("![secret](file:///etc/passwd)")).toBe("secret");
+  });
+
+  it("strips javascript: link URIs and keeps text", () => {
+    expect(markdownToMiniMarkdown("[click](javascript:void)")).toBe("click");
+  });
+
+  it("strips javascript: image URIs with nested parens", () => {
+    // Regex stops at first ), leaving trailing ) — acceptable degradation
+    const result = markdownToMiniMarkdown("![xss](javascript:alert(1))");
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("keeps valid https links", () => {
+    expect(markdownToMiniMarkdown("[click](https://example.com)")).toBe("[click](https://example.com)");
+  });
+
+  it("keeps valid http links", () => {
+    expect(markdownToMiniMarkdown("[click](http://example.com)")).toBe("[click](http://example.com)");
+  });
+
   it("preserves plain text", () => {
     expect(markdownToMiniMarkdown("hello world")).toBe("hello world");
   });

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -16,10 +16,15 @@ export function markdownToMiniMarkdown(text: string): string {
   // Strip inline code backticks
   result = result.replace(/`([^`]+)`/g, "$1");
 
-  // Convert markdown images to just URL
-  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, "$2");
+  // Convert markdown images to URL (only http/https protocols)
+  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt, url) =>
+    /^https?:\/\//i.test(url) ? url : (alt || ""),
+  );
 
-  // Keep links as-is — RC supports [text](url)
+  // Sanitize links — strip non-http(s) protocols
+  result = result.replace(/\[([^\]]*)\]\(([^)]+)\)/g, (_m, text, url) =>
+    /^https?:\/\//i.test(url) ? `[${text}](${url})` : text,
+  );
 
   // Strip horizontal rules
   result = result.replace(/^[-*_]{3,}\s*$/gm, "");

--- a/src/send.ts
+++ b/src/send.ts
@@ -2,6 +2,7 @@
 
 import type { RingCentralClient } from "./client.js";
 import { markdownToMiniMarkdown } from "./markdown.js";
+import { validateMediaUrl } from "./url-validator.js";
 
 export interface SendOptions {
   client: RingCentralClient;
@@ -17,6 +18,7 @@ export async function sendMessage(opts: SendOptions): Promise<{ postId: string }
 
   if (mediaUrl) {
     try {
+      validateMediaUrl(mediaUrl);
       const resp = await fetch(mediaUrl);
       if (resp.ok) {
         const buf = Buffer.from(await resp.arrayBuffer());

--- a/src/url-validator.test.ts
+++ b/src/url-validator.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { validateMediaUrl } from "./url-validator.js";
+
+describe("validateMediaUrl", () => {
+  it("allows valid https URLs", () => {
+    expect(() => validateMediaUrl("https://example.com/image.png")).not.toThrow();
+    expect(() => validateMediaUrl("https://cdn.example.com/file.jpg")).not.toThrow();
+  });
+
+  it("blocks http protocol", () => {
+    expect(() => validateMediaUrl("http://example.com/image.png")).toThrow("Blocked protocol");
+  });
+
+  it("blocks file protocol", () => {
+    expect(() => validateMediaUrl("file:///etc/passwd")).toThrow("Blocked protocol");
+  });
+
+  it("blocks data protocol", () => {
+    expect(() => validateMediaUrl("data:text/html,test")).toThrow("Blocked protocol");
+  });
+
+  it("blocks javascript protocol", () => {
+    expect(() => validateMediaUrl("javascript:alert(1)")).toThrow("Blocked protocol");
+  });
+
+  it("blocks localhost", () => {
+    expect(() => validateMediaUrl("https://localhost/secret")).toThrow("Blocked host");
+    expect(() => validateMediaUrl("https://localhost.localdomain/x")).toThrow("Blocked host");
+  });
+
+  it("blocks .local domains", () => {
+    expect(() => validateMediaUrl("https://server.local/data")).toThrow("Blocked host");
+  });
+
+  it("blocks .internal domains", () => {
+    expect(() => validateMediaUrl("https://metadata.google.internal/v1")).toThrow("Blocked host");
+    expect(() => validateMediaUrl("https://corp.internal/api")).toThrow("Blocked host");
+  });
+
+  it("blocks loopback IP 127.x.x.x", () => {
+    expect(() => validateMediaUrl("https://127.0.0.1/file")).toThrow("Blocked private IP");
+    expect(() => validateMediaUrl("https://127.0.0.2/file")).toThrow("Blocked private IP");
+  });
+
+  it("blocks 10.x.x.x (RFC 1918)", () => {
+    expect(() => validateMediaUrl("https://10.0.0.1/file")).toThrow("Blocked private IP");
+    expect(() => validateMediaUrl("https://10.255.255.255/file")).toThrow("Blocked private IP");
+  });
+
+  it("blocks 172.16-31.x.x (RFC 1918)", () => {
+    expect(() => validateMediaUrl("https://172.16.0.1/file")).toThrow("Blocked private IP");
+    expect(() => validateMediaUrl("https://172.31.255.255/file")).toThrow("Blocked private IP");
+  });
+
+  it("allows 172.15.x.x and 172.32.x.x", () => {
+    expect(() => validateMediaUrl("https://172.15.0.1/file")).not.toThrow();
+    expect(() => validateMediaUrl("https://172.32.0.1/file")).not.toThrow();
+  });
+
+  it("blocks 192.168.x.x (RFC 1918)", () => {
+    expect(() => validateMediaUrl("https://192.168.1.1/file")).toThrow("Blocked private IP");
+  });
+
+  it("blocks 169.254.x.x (link-local)", () => {
+    expect(() => validateMediaUrl("https://169.254.169.254/metadata")).toThrow("Blocked private IP");
+  });
+
+  it("blocks 0.0.0.0", () => {
+    expect(() => validateMediaUrl("https://0.0.0.0/file")).toThrow("Blocked private IP");
+  });
+
+  it("blocks IPv6 loopback", () => {
+    expect(() => validateMediaUrl("https://[::1]/file")).toThrow("Blocked private IP");
+  });
+
+  it("throws on invalid URLs", () => {
+    expect(() => validateMediaUrl("not-a-url")).toThrow("Invalid media URL");
+  });
+});

--- a/src/url-validator.ts
+++ b/src/url-validator.ts
@@ -1,0 +1,65 @@
+// SSRF guard — validates URLs before fetching external media.
+
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "metadata.google.internal",
+]);
+
+const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal"];
+
+function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (BLOCKED_HOSTS.has(h)) return true;
+  return BLOCKED_HOST_SUFFIXES.some((suffix) => h.endsWith(suffix));
+}
+
+function isPrivateIp(hostname: string): boolean {
+  // IPv6 loopback
+  if (hostname === "::1" || hostname === "[::1]") return true;
+
+  // IPv4 checks
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return false;
+  const nums = parts.map(Number);
+  if (nums.some((n) => isNaN(n) || n < 0 || n > 255)) return false;
+
+  const [a, b] = nums;
+  // 0.0.0.0
+  if (a === 0 && b === 0 && nums[2] === 0 && nums[3] === 0) return true;
+  // 127.x.x.x (loopback)
+  if (a === 127) return true;
+  // 10.x.x.x (RFC 1918)
+  if (a === 10) return true;
+  // 172.16-31.x.x (RFC 1918)
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.x.x (RFC 1918)
+  if (a === 192 && b === 168) return true;
+  // 169.254.x.x (link-local)
+  if (a === 169 && b === 254) return true;
+
+  return false;
+}
+
+export function validateMediaUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("Invalid media URL");
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error(`Blocked protocol: ${url.protocol}`);
+  }
+
+  const hostname = url.hostname.toLowerCase();
+
+  if (isBlockedHostname(hostname)) {
+    throw new Error(`Blocked host: ${hostname}`);
+  }
+
+  if (isPrivateIp(hostname)) {
+    throw new Error(`Blocked private IP: ${hostname}`);
+  }
+}


### PR DESCRIPTION
## Summary

Remediates all 6 security issues identified by the security team review.

## Changes

### 1. SSRF and Local File Exfiltration
- **New:** `src/url-validator.ts` — blocks non-HTTPS protocols, private/internal IPs (RFC 1918, loopback, link-local), and cloud metadata endpoints
- Wired into `sendMessage()` before any `fetch()` call

### 2. Authorization Bypass / Cross-Chat Manipulation
- `handleAction` now accepts `sessionChatId` and validates that chat-scoped actions target the active session's `NativeChannelId`
- Prevents prompt-injected agents from accessing chats the bot wasn't invited to

### 3. Human-in-the-Loop for Destructive Actions
- Protected actions (`delete-*`, `update-*`, `edit-message`) return a confirmation-required response with a nonce
- New `confirm-action` action type executes the pending action after user confirmation (TTL: 2 minutes)

### 4. Plain-text Credential Leakage in Error Logs
- Sanitized error messages in `refreshToken`, `getWSToken`, `getBotWSToken` to include only HTTP status code
- Raw response bodies containing JWT assertions are no longer logged

### 5. Markdown Injection via Image/Link Regex
- Image and link regex replacements now enforce `https?://` protocol whitelist
- `javascript:`, `data:`, `file:` URIs are stripped, falling back to alt text

### 6. Insecure Identity Verification in Self Only Mode
- **New:** `src/identity.ts` — caches the private app owner's extension ID at startup via `GET /extension/~`
- `handleInboundPost` verifies `post.creatorId` against the cached trusted identity when `selfOnly` is enabled

## Testing

- All 152 tests pass
- TypeScript compiles cleanly
- New test files: `url-validator.test.ts`, `identity.test.ts`
- Updated tests: `auth.test.ts`, `markdown.test.ts`, `actions-adapter.test.ts`