### PR TITLE
Improve RingCentral live smoke chat preflight

### DIFF
--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: boolean
         default: true
+      ws_timeout_ms:
+        description: "Timeout for bot WebSocket connect/receive checks"
+        required: false
+        default: "30000"
 
 jobs:
   ringcentral-live-smoke:
@@ -26,6 +30,7 @@ jobs:
       RC_E2E_CHAT_ID: ${{ secrets.RC_E2E_CHAT_ID }}
       RC_E2E_RECORD_COUNT: ${{ inputs.record_count }}
       RC_E2E_CLEANUP: ${{ inputs.cleanup }}
+      RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}
       RC_USER_CLIENT_ID: ${{ secrets.RC_USER_CLIENT_ID }}
       RC_USER_CLIENT_SECRET: ${{ secrets.RC_USER_CLIENT_SECRET }}

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { createBotClient, createOwnerClient } from "../client.js";
 import { createRingCentralHistoryTool } from "../history-tool.js";
 import { deleteMessage, sendMessage } from "../send.js";
+import { extractChatId } from "../targets.js";
+import type { RingCentralClient } from "../client.js";
 import type { Post } from "../types.js";
 
 const required = readBooleanEnv("RC_E2E_REQUIRED", false);
@@ -33,8 +35,9 @@ liveDescribe("RingCentral live smoke", () => {
       const ownerExtension = await ownerClient.getExtensionInfo();
       expect(ownerExtension.id).toBeTruthy();
 
-      const chat = await ownerClient.getChat(env.chatId);
+      const chat = await getChatMetadata({ ownerClient, botClient, chatId: env.chatId });
       expect(chat.id).toBe(env.chatId);
+      await assertOwnerCanReadHistory(ownerClient, env.chatId, env.recordCount);
 
       const sent = await sendMessage({
         client: botClient,
@@ -101,7 +104,7 @@ function readLiveEnv(): LiveEnv {
     ownerClientId: readRequired("RC_USER_CLIENT_ID"),
     ownerClientSecret: readRequired("RC_USER_CLIENT_SECRET"),
     ownerJwtToken: readRequired("RC_USER_JWT_TOKEN"),
-    chatId: readRequired("RC_E2E_CHAT_ID"),
+    chatId: normalizeChatId(readRequired("RC_E2E_CHAT_ID")),
     recordCount: readRecordCount(),
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", true),
   };
@@ -109,6 +112,10 @@ function readLiveEnv(): LiveEnv {
     throw new Error(`Missing RingCentral live smoke variables: ${missing.join(", ")}`);
   }
   return env;
+}
+
+function normalizeChatId(raw: string): string {
+  return extractChatId(raw) ?? raw;
 }
 
 function readRecordCount(): number {
@@ -168,6 +175,44 @@ async function readRecentPosts(
     return (await client.listPosts(chatId, recordCount)).records ?? [];
   } catch {
     return (await client.listLegacyGroupPosts(chatId, recordCount)).records ?? [];
+  }
+}
+
+async function getChatMetadata(params: {
+  ownerClient: RingCentralClient;
+  botClient: RingCentralClient;
+  chatId: string;
+}) {
+  try {
+    return await params.ownerClient.getChat(params.chatId);
+  } catch (ownerErr) {
+    try {
+      const chat = await params.botClient.getChat(params.chatId);
+      console.log(
+        "[ringcentral-live] owner chat metadata lookup failed; bot metadata lookup succeeded",
+      );
+      return chat;
+    } catch {
+      throw ownerErr;
+    }
+  }
+}
+
+async function assertOwnerCanReadHistory(
+  ownerClient: RingCentralClient,
+  chatId: string,
+  recordCount: number,
+): Promise<void> {
+  try {
+    await readRecentPosts(ownerClient, chatId, Math.min(recordCount, 1));
+  } catch (err) {
+    throw new Error(
+      [
+        `Owner credentials cannot read RingCentral chat ${chatId}.`,
+        "Ensure RC_USER_JWT_TOKEN belongs to a user who is a member of RC_E2E_CHAT_ID.",
+        `Original error: ${err instanceof Error ? err.message : String(err)}`,
+      ].join(" "),
+    );
   }
 }
 

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { createBotClient, createOwnerClient } from "../client.js";
+import { describe, it } from "vitest";
+import {
+  RingCentralApiError,
+  createBotClient,
+  createOwnerClient,
+  type RingCentralClient,
+} from "../client.js";
 import { createRingCentralHistoryTool } from "../history-tool.js";
-import { deleteMessage, sendMessage } from "../send.js";
+import { RingCentralWebSocketMonitor } from "../monitor.js";
+import { sendMessage } from "../send.js";
 import { extractChatId } from "../targets.js";
-import type { RingCentralClient } from "../client.js";
-import type { Post } from "../types.js";
+import type { ExtensionInfo, Post } from "../types.js";
 
 const required = readBooleanEnv("RC_E2E_REQUIRED", false);
 const enabled = readBooleanEnv("RC_E2E_ENABLED", false);
@@ -16,7 +21,7 @@ if (required && !enabled) {
 const liveDescribe = enabled ? describe : describe.skip;
 
 liveDescribe("RingCentral live smoke", () => {
-  it("sends, reads, verifies history, and cleans up a test group message", async () => {
+  it("validates bot send, owner read, history, bot receive, bot read, and bot reply", async () => {
     const env = readLiveEnv();
     const botClient = createBotClient(env.serverUrl, env.botToken);
     const ownerClient = createOwnerClient(
@@ -25,55 +30,54 @@ liveDescribe("RingCentral live smoke", () => {
       env.ownerClientSecret,
       env.ownerJwtToken,
     );
-    const uniqueText = buildUniqueText();
-    const createdPostIds: string[] = [];
+    const createdBotPostIds: string[] = [];
+    const createdOwnerPostIds: string[] = [];
 
     try {
-      const botExtension = await botClient.getExtensionInfo();
-      expect(botExtension.id).toBeTruthy();
+      logSafe("live_start", { chat: maskId(env.chatId) });
 
-      const ownerExtension = await ownerClient.getExtensionInfo();
-      expect(ownerExtension.id).toBeTruthy();
+      const botExtension = await liveStep("bot_auth", () => botClient.getExtensionInfo());
+      assertLive(!!botExtension.id, "bot_auth");
 
-      const chat = await getChatMetadata({ ownerClient, botClient, chatId: env.chatId });
-      expect(chat.id).toBe(env.chatId);
-      await assertOwnerCanReadHistory(ownerClient, env.chatId, env.recordCount);
+      const ownerExtension = await liveStep("owner_auth", () => ownerClient.getExtensionInfo());
+      assertLive(!!ownerExtension.id, "owner_auth");
 
-      const sent = await sendMessage({
-        client: botClient,
-        chatId: env.chatId,
-        text: uniqueText,
-        convertMarkdown: false,
-        replyToMode: "off",
+      const chat = await liveStep("chat_metadata_preflight", () =>
+        getChatMetadata({ ownerClient, botClient, chatId: env.chatId }),
+      );
+      assertLive(chat.id === env.chatId, "chat_metadata_preflight");
+
+      await liveStep("owner_history_preflight", () =>
+        assertClientCanReadHistory(ownerClient, env.chatId, env.recordCount),
+      );
+      await liveStep("bot_history_preflight", () =>
+        assertClientCanReadHistory(botClient, env.chatId, env.recordCount),
+      );
+
+      await runBotSendOwnerReadScenario({
+        env,
+        botClient,
+        ownerClient,
+        createdBotPostIds,
       });
-      expect(sent?.postId).toBeTruthy();
-      if (sent?.postId) {
-        createdPostIds.push(sent.postId);
-      }
-
-      const found = await waitForPost(ownerClient, env.chatId, uniqueText, env.recordCount);
-      expect(found?.id).toBe(sent?.postId);
-      expect(found?.text).toContain(uniqueText);
-
-      const historyText = await readHistoryToolText({
-        serverUrl: env.serverUrl,
-        botToken: env.botToken,
-        ownerClientId: env.ownerClientId,
-        ownerClientSecret: env.ownerClientSecret,
-        ownerJwtToken: env.ownerJwtToken,
-        chatId: env.chatId,
-        recordCount: env.recordCount,
+      await runOwnerSendBotReceiveScenario({
+        env,
+        botClient,
+        ownerClient,
+        botExtension,
+        ownerExtension,
+        createdBotPostIds,
+        createdOwnerPostIds,
       });
-      expect(historyText).toContain(uniqueText);
     } finally {
-      if (env.cleanup) {
-        for (const postId of createdPostIds.reverse()) {
-          await deleteMessage(botClient, env.chatId, postId);
-          console.log(`[ringcentral-live] cleanup requested for post ${postId}`);
-        }
-      } else {
-        console.log(`[ringcentral-live] cleanup disabled; post ids: ${createdPostIds.join(", ")}`);
-      }
+      await cleanupPosts({
+        cleanup: env.cleanup,
+        chatId: env.chatId,
+        botClient,
+        ownerClient,
+        botPostIds: createdBotPostIds,
+        ownerPostIds: createdOwnerPostIds,
+      });
     }
   });
 });
@@ -87,6 +91,116 @@ interface LiveEnv {
   chatId: string;
   recordCount: number;
   cleanup: boolean;
+  wsTimeoutMs: number;
+}
+
+interface LiveClients {
+  env: LiveEnv;
+  botClient: RingCentralClient;
+  ownerClient: RingCentralClient;
+  createdBotPostIds: string[];
+  createdOwnerPostIds?: string[];
+}
+
+async function runBotSendOwnerReadScenario(params: LiveClients): Promise<void> {
+  const uniqueText = buildUniqueText("bot-send");
+  const sent = await liveStep("bot_send", () =>
+    sendMessage({
+      client: params.botClient,
+      chatId: params.env.chatId,
+      text: uniqueText,
+      convertMarkdown: false,
+      replyToMode: "off",
+    }),
+  );
+  assertLive(!!sent?.postId, "bot_send");
+  params.createdBotPostIds.push(sent!.postId);
+  logSafe("bot_send", { sent: true });
+
+  const found = await liveStep("owner_read_bot_message", () =>
+    waitForPost(params.ownerClient, params.env.chatId, uniqueText, params.env.recordCount),
+  );
+  assertLive(found?.id === sent?.postId && !!found?.text?.includes(uniqueText), "owner_read_bot_message");
+  logSafe("owner_read_bot_message", { found: true });
+
+  const historyText = await liveStep("history_tool_read", () =>
+    readHistoryToolText({
+      serverUrl: params.env.serverUrl,
+      botToken: params.env.botToken,
+      ownerClientId: params.env.ownerClientId,
+      ownerClientSecret: params.env.ownerClientSecret,
+      ownerJwtToken: params.env.ownerJwtToken,
+      chatId: params.env.chatId,
+      recordCount: params.env.recordCount,
+    }),
+  );
+  assertLive(historyText.includes(uniqueText), "history_tool_read");
+  logSafe("history_tool_read", { found: true });
+}
+
+async function runOwnerSendBotReceiveScenario(
+  params: LiveClients & {
+    botExtension: ExtensionInfo;
+    ownerExtension: ExtensionInfo;
+    createdOwnerPostIds: string[];
+  },
+): Promise<void> {
+  const ownerText = buildUniqueText("owner-send");
+  const replyText = buildUniqueText("bot-reply");
+  const wsWaiter = startBotWebSocketWait({
+    botClient: params.botClient,
+    botPersonId: String(params.botExtension.id ?? ""),
+    chatId: params.env.chatId,
+    expectedText: ownerText,
+    timeoutMs: params.env.wsTimeoutMs,
+  });
+  try {
+    await liveStep("bot_ws_connect", () =>
+      withTimeout(wsWaiter.connected, params.env.wsTimeoutMs, "bot_ws_connect"),
+    );
+
+    const ownerPost = await liveStep("owner_send", () =>
+      params.ownerClient.sendPost(params.env.chatId, ownerText),
+    );
+    assertLive(!!ownerPost.id, "owner_send");
+    params.createdOwnerPostIds.push(ownerPost.id);
+    logSafe("owner_send", { sent: true });
+
+    const received = await liveStep("bot_ws_receive", () =>
+      withTimeout(wsWaiter.received, params.env.wsTimeoutMs, "bot_ws_receive"),
+    );
+    assertLive(received.groupId === params.env.chatId && !!received.text?.includes(ownerText), "bot_ws_receive");
+    logSafe("bot_ws_receive", { ws_received: true });
+
+    const botRead = await liveStep("bot_read_owner_message", () =>
+      waitForPost(params.botClient, params.env.chatId, ownerText, params.env.recordCount),
+    );
+    assertLive(!!botRead?.text?.includes(ownerText), "bot_read_owner_message");
+    logSafe("bot_read_owner_message", { bot_read_found: true });
+
+    const reply = await liveStep("bot_reply", () =>
+      sendMessage({
+        client: params.botClient,
+        chatId: params.env.chatId,
+        text: replyText,
+        convertMarkdown: false,
+        replyToMode: "off",
+      }),
+    );
+    assertLive(!!reply?.postId, "bot_reply");
+    params.createdBotPostIds.push(reply!.postId);
+    logSafe("bot_reply", { sent: true });
+
+    const ownerReadReply = await liveStep("owner_read_bot_reply", () =>
+      waitForPost(params.ownerClient, params.env.chatId, replyText, params.env.recordCount),
+    );
+    assertLive(!!ownerReadReply?.text?.includes(replyText), "owner_read_bot_reply");
+    logSafe("owner_read_bot_reply", { owner_read_found: true });
+  } finally {
+    await wsWaiter.stop();
+  }
+
+  assertLive(String(params.ownerExtension.id ?? ""), "owner_auth");
 }
 
 function readLiveEnv(): LiveEnv {
@@ -107,6 +221,7 @@ function readLiveEnv(): LiveEnv {
     chatId: normalizeChatId(readRequired("RC_E2E_CHAT_ID")),
     recordCount: readRecordCount(),
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", true),
+    wsTimeoutMs: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
   };
   if (missing.length > 0) {
     throw new Error(`Missing RingCentral live smoke variables: ${missing.join(", ")}`);
@@ -119,11 +234,20 @@ function normalizeChatId(raw: string): string {
 }
 
 function readRecordCount(): number {
-  const parsed = Number(process.env.RC_E2E_RECORD_COUNT ?? "50");
+  return readPositiveIntegerEnv("RC_E2E_RECORD_COUNT", 50, 1, 1000);
+}
+
+function readPositiveIntegerEnv(
+  name: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = Number(process.env[name] ?? String(fallback));
   if (!Number.isFinite(parsed)) {
-    return 50;
+    return fallback;
   }
-  return Math.min(Math.max(Math.trunc(parsed), 1), 1000);
+  return Math.min(Math.max(Math.trunc(parsed), min), max);
 }
 
 function readBooleanEnv(name: string, fallback: boolean): boolean {
@@ -134,14 +258,14 @@ function readBooleanEnv(name: string, fallback: boolean): boolean {
   return ["1", "true", "yes", "on"].includes(raw);
 }
 
-function buildUniqueText(): string {
+function buildUniqueText(label: string): string {
   const runId = process.env.GITHUB_RUN_ID ?? "local";
   const attempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
-  return `[openclaw-ringcentral-e2e:${runId}:${attempt}:${Date.now()}]`;
+  return `[openclaw-ringcentral-e2e:${label}:${runId}:${attempt}:${Date.now()}]`;
 }
 
 async function waitForPost(
-  client: ReturnType<typeof createOwnerClient>,
+  client: RingCentralClient,
   chatId: string,
   expectedText: string,
   recordCount: number,
@@ -157,7 +281,7 @@ async function waitForPost(
 }
 
 async function findRecentPost(
-  client: ReturnType<typeof createOwnerClient>,
+  client: RingCentralClient,
   chatId: string,
   expectedText: string,
   recordCount: number,
@@ -167,7 +291,7 @@ async function findRecentPost(
 }
 
 async function readRecentPosts(
-  client: ReturnType<typeof createOwnerClient>,
+  client: RingCentralClient,
   chatId: string,
   recordCount: number,
 ): Promise<Post[]> {
@@ -185,35 +309,111 @@ async function getChatMetadata(params: {
 }) {
   try {
     return await params.ownerClient.getChat(params.chatId);
-  } catch (ownerErr) {
+  } catch {
     try {
       const chat = await params.botClient.getChat(params.chatId);
-      console.log(
-        "[ringcentral-live] owner chat metadata lookup failed; bot metadata lookup succeeded",
-      );
+      logSafe("chat_metadata_preflight", { owner_lookup: false, bot_lookup: true });
       return chat;
-    } catch {
-      throw ownerErr;
+    } catch (err) {
+      throw err;
     }
   }
 }
 
-async function assertOwnerCanReadHistory(
-  ownerClient: RingCentralClient,
+async function assertClientCanReadHistory(
+  client: RingCentralClient,
   chatId: string,
   recordCount: number,
 ): Promise<void> {
-  try {
-    await readRecentPosts(ownerClient, chatId, Math.min(recordCount, 1));
-  } catch (err) {
-    throw new Error(
-      [
-        `Owner credentials cannot read RingCentral chat ${chatId}.`,
-        "Ensure RC_USER_JWT_TOKEN belongs to a user who is a member of RC_E2E_CHAT_ID.",
-        `Original error: ${err instanceof Error ? err.message : String(err)}`,
-      ].join(" "),
-    );
+  await readRecentPosts(client, chatId, Math.min(recordCount, 1));
+}
+
+function startBotWebSocketWait(params: {
+  botClient: RingCentralClient;
+  botPersonId: string;
+  chatId: string;
+  expectedText: string;
+  timeoutMs: number;
+}): {
+  connected: Promise<void>;
+  received: Promise<Post>;
+  stop: () => Promise<void>;
+} {
+  const abortController = new AbortController();
+  const connected = createDeferred<void>();
+  const received = createDeferred<Post>();
+  const monitor = new RingCentralWebSocketMonitor({
+    client: params.botClient,
+    ownCreatorId: params.botPersonId,
+    filterOwnCreator: true,
+    abortSignal: abortController.signal,
+    ignoredTexts: [],
+    onConnected: () => {
+      logSafe("bot_ws_connect", { ws_connected: true });
+      connected.resolve();
+    },
+    onDisconnected: (err) => {
+      if (!abortController.signal.aborted) {
+        connected.reject(err ?? new Error("ws disconnected"));
+        received.reject(err ?? new Error("ws disconnected"));
+      }
+    },
+    onMessage: (post) => {
+      if (post.groupId === params.chatId && post.text?.includes(params.expectedText)) {
+        received.resolve(post);
+      }
+    },
+    log: () => undefined,
+  });
+  const monitorDone = monitor.start().catch((err) => {
+    if (!abortController.signal.aborted) {
+      connected.reject(err);
+      received.reject(err);
+    }
+  });
+  return {
+    connected: connected.promise,
+    received: received.promise,
+    stop: async () => {
+      abortController.abort();
+      await monitorDone.catch(() => undefined);
+    },
+  };
+}
+
+async function cleanupPosts(params: {
+  cleanup: boolean;
+  chatId: string;
+  botClient: RingCentralClient;
+  ownerClient: RingCentralClient;
+  botPostIds: string[];
+  ownerPostIds: string[];
+}): Promise<void> {
+  if (!params.cleanup) {
+    logSafe("cleanup", { enabled: false });
+    return;
   }
+
+  let cleanupBotPost = true;
+  let cleanupOwnerPost = true;
+  for (const postId of params.botPostIds.reverse()) {
+    try {
+      await params.botClient.deletePost(params.chatId, postId);
+    } catch {
+      cleanupBotPost = false;
+    }
+  }
+  for (const postId of params.ownerPostIds.reverse()) {
+    try {
+      await params.ownerClient.deletePost(params.chatId, postId);
+    } catch {
+      cleanupOwnerPost = false;
+    }
+  }
+  logSafe("cleanup", {
+    cleanup_bot_post: cleanupBotPost,
+    cleanup_owner_post: cleanupOwnerPost,
+  });
 }
 
 async function readHistoryToolText(params: {
@@ -248,6 +448,109 @@ async function readHistoryToolText(params: {
     .map((item) => (item.type === "text" ? item.text : ""))
     .filter(Boolean)
     .join("\n");
+}
+
+async function liveStep<T>(stage: string, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    const result = await fn();
+    logSafe(stage, { ok: true, duration_ms: Date.now() - start });
+    return result;
+  } catch (err) {
+    throw toSafeLiveError(stage, err);
+  }
+}
+
+function assertLive(condition: unknown, stage: string): asserts condition {
+  if (!condition) {
+    throw new Error(`RingCentral live smoke failed at ${stage}: assertion failed`);
+  }
+}
+
+function toSafeLiveError(stage: string, err: unknown): Error {
+  return new Error(`RingCentral live smoke failed at ${stage}: ${summarizeSafeError(err)}`);
+}
+
+function summarizeSafeError(err: unknown): string {
+  if (err instanceof RingCentralApiError) {
+    const code = readRingCentralErrorCode(err.body);
+    return `HTTP ${err.status}${code ? ` ${code}` : ""}`;
+  }
+  if (err instanceof TimeoutError) {
+    return "timeout";
+  }
+  return "failed";
+}
+
+function readRingCentralErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { errors?: Array<{ errorCode?: unknown }> };
+    const code = parsed.errors?.find((item) => typeof item.errorCode === "string")?.errorCode;
+    return typeof code === "string" ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function maskId(value: unknown): string {
+  const raw = String(value ?? "");
+  if (!raw) {
+    return "<masked>";
+  }
+  return `<masked:length=${raw.length}:tail=${raw.slice(-4)}>`;
+}
+
+function logSafe(event: string, details: Record<string, boolean | number | string> = {}): void {
+  const suffix = Object.entries(details)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ");
+  console.log(`[ringcentral-live] event=${event}${suffix ? ` ${suffix}` : ""}`);
+}
+
+function createDeferred<T>() {
+  let settled = false;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = (value) => {
+      if (!settled) {
+        settled = true;
+        res(value);
+      }
+    };
+    reject = (reason) => {
+      if (!settled) {
+        settled = true;
+        rej(reason);
+      }
+    };
+  });
+  return { promise, resolve, reject };
+}
+
+class TimeoutError extends Error {
+  constructor(readonly stage: string) {
+    super(stage);
+    this.name = "TimeoutError";
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  stage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new TimeoutError(stage)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Normalize RC_E2E_CHAT_ID so the live smoke test accepts bare ids and ringcentral/rc target strings.
- Let chat metadata preflight fall back from owner client to bot client.
- Add an explicit owner history preflight so failures clearly state that the RC_USER_JWT_TOKEN user must be able to read RC_E2E_CHAT_ID.

## Context
The live workflow received all secrets successfully, but failed with RingCentral 404 CMN-102 on ownerClient.getChat(chatId). The bot may be in the test group, but owner history validation still requires the owner JWT user to have access to the same chat.

## Verification
- pnpm test
- pnpm typecheck
- RC_E2E_ENABLED=false pnpm exec vitest run src/live/ringcentral-live.test.ts --testTimeout=60000