### PR TITLE
Fix RingCentral live WebSocket token connection

### DIFF
--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -342,6 +342,8 @@ function startBotWebSocketWait(params: {
   const abortController = new AbortController();
   const connected = createDeferred<void>();
   const received = createDeferred<Post>();
+  connected.promise.catch(() => undefined);
+  received.promise.catch(() => undefined);
   const monitor = new RingCentralWebSocketMonitor({
     client: params.botClient,
     ownCreatorId: params.botPersonId,
@@ -497,7 +499,7 @@ function maskId(value: unknown): string {
   if (!raw) {
     return "<masked>";
   }
-  return `<masked:length=${raw.length}:tail=${raw.slice(-4)}>`;
+  return `<masked:length=${raw.length}>`;
 }
 
 function logSafe(event: string, details: Record<string, boolean | number | string> = {}): void {

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractPostFromWsFrame, markSentPost, shouldProcessPost } from "./monitor.js";
+import { buildWebSocketUrl, extractPostFromWsFrame, markSentPost, shouldProcessPost } from "./monitor.js";
 import { ANSWER_START } from "./shared.js";
 
 function makeWSEvent(overrides?: Record<string, unknown>) {
@@ -75,5 +75,25 @@ describe("markSentPost", () => {
     markSentPost(sentPosts, "p1");
     expect(sentPosts.has("p1")).toBe(true);
     expect(sentPosts.get("p1")).toBeGreaterThan(0);
+  });
+});
+
+describe("buildWebSocketUrl", () => {
+  it("adds ws access token as access_token query param", () => {
+    expect(buildWebSocketUrl({ uri: "wss://example.test/ws", ws_access_token: "token-1" })).toBe(
+      "wss://example.test/ws?access_token=token-1",
+    );
+  });
+
+  it("preserves existing query params", () => {
+    expect(buildWebSocketUrl({ uri: "wss://example.test/ws?x=1", ws_access_token: "token-1" })).toBe(
+      "wss://example.test/ws?x=1&access_token=token-1",
+    );
+  });
+
+  it("does not replace an existing access token", () => {
+    expect(buildWebSocketUrl({ uri: "wss://example.test/ws?access_token=existing", ws_access_token: "token-1" })).toBe(
+      "wss://example.test/ws?access_token=existing",
+    );
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -56,7 +56,7 @@ export class RingCentralWebSocketMonitor {
   private async connectAndListen(log: (...args: unknown[]) => void): Promise<void> {
     const { client, onConnected, abortSignal } = this.opts;
     const wsToken = await client.createWebSocketToken();
-    const ws = new WebSocket(wsToken.uri);
+    const ws = new WebSocket(buildWebSocketUrl(wsToken));
     let pongTimer: ReturnType<typeof setTimeout> | undefined;
     let pingTimer: ReturnType<typeof setInterval> | undefined;
     let connected = false;
@@ -171,6 +171,17 @@ export class RingCentralWebSocketMonitor {
     log(`[rc-monitor] received post chatId=${post.groupId} creatorId=${post.creatorId}`);
     this.opts.onMessage(post);
   }
+}
+
+export function buildWebSocketUrl(wsToken: { uri: string; ws_access_token?: string }): string {
+  if (!wsToken.ws_access_token) {
+    return wsToken.uri;
+  }
+  const url = new URL(wsToken.uri);
+  if (!url.searchParams.has("access_token")) {
+    url.searchParams.set("access_token", wsToken.ws_access_token);
+  }
+  return url.toString();
 }
 
 export async function startMonitor(opts: MonitorOptions): Promise<void> {


### PR DESCRIPTION
## Summary
- Add ws_access_token to the RingCentral WebSocket URL as the access_token query parameter.
- Cover WebSocket URL construction with unit tests.
- Prevent live smoke WebSocket wait promises from surfacing unhandled rejections.
- Tighten live smoke ID masking to avoid exposing chat id suffixes.

## Context
The live workflow passed REST checks but failed at bot_ws_connect with RingCentral close code 4400: the WebSocket server did not receive authorization. The wstoken response includes ws_access_token, but the monitor was connecting to the bare uri.

## Verification
- pnpm test
- pnpm typecheck
- RC_E2E_ENABLED=false pnpm exec vitest run src/live/ringcentral-live.test.ts --testTimeout=60000