### PR TITLE
Accept RingCentral WebSocket post body events

### DIFF
--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -43,6 +43,25 @@ describe("extractPostFromWsFrame", () => {
     expect(extractPostFromWsFrame(event)).toEqual(expect.objectContaining({ id: "post-1" }));
   });
 
+  it("extracts Hermes-style array PostAdded bodies", () => {
+    expect(
+      extractPostFromWsFrame([
+        { type: "ServerNotification", status: 200 },
+        {
+          event: "/team-messaging/v1/posts",
+          body: {
+            eventType: "PostAdded",
+            id: "post-2",
+            groupId: "chat-1",
+            text: "Hello from body eventType",
+            creatorId: "user-2",
+            creationTime: "2026-01-01T00:00:00Z",
+          },
+        },
+      ]),
+    ).toEqual(expect.objectContaining({ id: "post-2", text: "Hello from body eventType" }));
+  });
+
   it("ignores non-PostAdded events", () => {
     const [, event] = makeWSEvent({ event: "/team-messaging/v1/posts?eventType=PostChanged" });
     expect(extractPostFromWsFrame(event)).toBeNull();

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -143,6 +143,7 @@ export class RingCentralWebSocketMonitor {
 
         const post = extractPostFromWsFrame(parsed);
         if (post) {
+          onDiagnostic?.("ws_post_received");
           this.handlePost(post, log);
         }
       });
@@ -211,15 +212,18 @@ export function extractPostFromWsFrame(frame: unknown): Post | null {
     return null;
   }
   const record = event as Partial<WSEvent> & Record<string, unknown>;
-  if (typeof record.event !== "string" || !record.event.includes("PostAdded")) {
-    return null;
-  }
   const post = record.body;
   if (!post || typeof post !== "object") {
     return null;
   }
   const candidate = post as Post;
-  return candidate.type === "TextMessage" ? candidate : null;
+  if (!isPostAddedEvent(record, candidate)) {
+    return null;
+  }
+  if (candidate.type && candidate.type !== "TextMessage") {
+    return null;
+  }
+  return typeof candidate.text === "string" ? candidate : null;
 }
 
 export function shouldProcessPost(
@@ -300,6 +304,13 @@ function readRejectedClientRequestStatus(value: unknown): number | undefined {
     return undefined;
   }
   return status;
+}
+
+function isPostAddedEvent(record: Record<string, unknown>, post: Partial<Post>): boolean {
+  if (post.eventType === "PostAdded") {
+    return true;
+  }
+  return typeof record.event === "string" && record.event.includes("PostAdded");
 }
 
 function createMessageId(): string {


### PR DESCRIPTION
## Summary
- Accept RingCentral WebSocket post payloads that mark the event on body.eventType
- Allow PostAdded text bodies that omit the REST-style type field
- Emit a sanitized ws_post_received diagnostic when a post frame is parsed

## Test Plan
- pnpm test
- pnpm typecheck

## Context
The latest live smoke run connected the WebSocket and confirmed subscription successfully, then timed out at bot_ws_receive. Hermes handles RingCentral WebSocket notifications by reading payload.body.eventType, while the TypeScript monitor only accepted outer event strings containing PostAdded plus body.type === TextMessage. That made real post notifications easy to drop before the live assertion could match them.