### PR TITLE
Run RingCentral live smoke on main pushes

### DIFF
--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -1,6 +1,9 @@
 name: RingCentral Live Smoke
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       record_count:
@@ -28,9 +31,9 @@ jobs:
       RC_E2E_ENABLED: "true"
       RC_SERVER_URL: ${{ secrets.RC_SERVER_URL || 'https://platform.ringcentral.com' }}
       RC_E2E_CHAT_ID: ${{ secrets.RC_E2E_CHAT_ID }}
-      RC_E2E_RECORD_COUNT: ${{ inputs.record_count }}
-      RC_E2E_CLEANUP: ${{ inputs.cleanup }}
-      RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms }}
+      RC_E2E_RECORD_COUNT: ${{ inputs.record_count || '50' }}
+      RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == false && 'false' || 'true' }}
+      RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}
       RC_USER_CLIENT_ID: ${{ secrets.RC_USER_CLIENT_ID }}
       RC_USER_CLIENT_SECRET: ${{ secrets.RC_USER_CLIENT_SECRET }}

--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       record_count:
@@ -34,6 +37,8 @@ jobs:
       RC_E2E_RECORD_COUNT: ${{ inputs.record_count || '50' }}
       RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == false && 'false' || 'true' }}
       RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
+      RC_E2E_SOURCE_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
+      RC_E2E_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}
       RC_USER_CLIENT_ID: ${{ secrets.RC_USER_CLIENT_ID }}
       RC_USER_CLIENT_SECRET: ${{ secrets.RC_USER_CLIENT_SECRET }}

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -261,7 +261,16 @@ function readBooleanEnv(name: string, fallback: boolean): boolean {
 function buildUniqueText(label: string): string {
   const runId = process.env.GITHUB_RUN_ID ?? "local";
   const attempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
-  return `[openclaw-ringcentral-e2e:${label}:${runId}:${attempt}:${Date.now()}]`;
+  const marker = `[openclaw-ringcentral-e2e:${label}:${runId}:${attempt}:${Date.now()}]`;
+  const sourceUrl = process.env.RC_E2E_SOURCE_URL?.trim();
+  const commitSha = process.env.RC_E2E_COMMIT_SHA?.trim();
+  return [
+    marker,
+    sourceUrl ? `source: ${sourceUrl}` : "",
+    commitSha ? `commit: ${commitSha}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 async function waitForPost(


### PR DESCRIPTION
## Summary
- Trigger RingCentral Live Smoke on pushes to main, including PR merge commits
- Keep workflow_dispatch for manual runs
- Add push-safe defaults for record_count, cleanup, and ws_timeout_ms because push events do not provide workflow inputs

## Test Plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ringcentral-live-smoke.yml"); puts "yaml ok"'

## Notes
The automatic main run uses cleanup=true, record_count=50, and ws_timeout_ms=30000.