### PR TITLE
Default RingCentral live smoke cleanup off

### DIFF
--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -17,7 +17,7 @@ on:
         description: "Delete test messages after verification"
         required: false
         type: boolean
-        default: true
+        default: false
       ws_timeout_ms:
         description: "Timeout for bot WebSocket connect/receive checks"
         required: false
@@ -35,7 +35,7 @@ jobs:
       RC_SERVER_URL: ${{ secrets.RC_SERVER_URL || 'https://platform.ringcentral.com' }}
       RC_E2E_CHAT_ID: ${{ secrets.RC_E2E_CHAT_ID }}
       RC_E2E_RECORD_COUNT: ${{ inputs.record_count || '50' }}
-      RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == false && 'false' || 'true' }}
+      RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == true && 'true' || 'false' }}
       RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
       RC_E2E_SOURCE_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
       RC_E2E_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -78,6 +78,13 @@ liveDescribe("RingCentral live smoke", () => {
         createdBotPostIds,
         createdOwnerPostIds,
       });
+      await runThreadedReplyScenario({
+        env,
+        botClient,
+        ownerClient,
+        createdBotPostIds,
+        createdOwnerPostIds,
+      });
     } catch (err) {
       summary.fail(err);
       throw err;
@@ -340,6 +347,45 @@ async function runOwnerSendBotReceiveScenario(
   assertLive(String(params.ownerExtension.id ?? ""), "owner_auth");
 }
 
+async function runThreadedReplyScenario(
+  params: LiveClients & {
+    createdOwnerPostIds: string[];
+  },
+): Promise<void> {
+  const rootText = buildUniqueText("owner-thread-root");
+  const replyText = buildUniqueText("bot-thread-reply");
+
+  const root = await liveStep("owner_thread_root_send", () =>
+    params.ownerClient.sendPost(params.env.chatId, rootText),
+  );
+  assertLive(!!root.id, "owner_thread_root_send");
+  const rootId = String(root.id);
+  params.createdOwnerPostIds.push(rootId);
+  logSafe("owner_thread_root_send", { sent: true });
+
+  const reply = await liveStep("bot_thread_reply", () =>
+    sendMessage({
+      client: params.botClient,
+      chatId: params.env.chatId,
+      text: replyText,
+      convertMarkdown: false,
+      replyToId: rootId,
+    }),
+  );
+  assertLive(!!reply?.postId, "bot_thread_reply");
+  params.createdBotPostIds.push(reply!.postId);
+  logSafe("bot_thread_reply", { sent: true });
+
+  const ownerReadReply = await liveStep("owner_read_thread_reply", () =>
+    waitForPost(params.ownerClient, params.env.chatId, replyText, params.env.recordCount),
+  );
+  assertLive(
+    ownerReadReply?.id === reply?.postId && hasThreadMetadata(ownerReadReply, rootId),
+    "owner_read_thread_reply",
+  );
+  logSafe("owner_read_thread_reply", { owner_read_found: true, thread_metadata: true });
+}
+
 function readLiveEnv(): LiveEnv {
   const missing: string[] = [];
   const readRequired = (name: string) => {
@@ -434,6 +480,19 @@ async function findRecentPost(
 ): Promise<Post | undefined> {
   const posts = await readRecentPosts(client, chatId, recordCount);
   return posts.find((post) => post.text?.includes(expectedText));
+}
+
+function hasThreadMetadata(post: Post, rootPostId: string): boolean {
+  const metadata = post as Post & {
+    parentId?: string | number | null;
+    rootPostId?: string | number | null;
+    rootId?: string | number | null;
+  };
+  const parent = metadata.parentPostId ?? metadata.parentId;
+  if (parent && String(parent) === rootPostId) {
+    return true;
+  }
+  return Boolean(metadata.threadId || metadata.rootPostId || metadata.rootId);
 }
 
 async function readRecentPosts(

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -233,6 +233,9 @@ function buildBaseSummaryContext(): Record<string, SummaryDetail> {
     event: process.env.GITHUB_EVENT_NAME ?? "local",
     source_present: Boolean(process.env.RC_E2E_SOURCE_URL?.trim()),
     commit_present: Boolean(process.env.RC_E2E_COMMIT_SHA?.trim()),
+    cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
+    record_count: readRecordCount(),
+    ws_timeout_ms: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
   };
 }
 
@@ -354,7 +357,7 @@ function readLiveEnv(): LiveEnv {
     ownerJwtToken: readRequired("RC_USER_JWT_TOKEN"),
     chatId: normalizeChatId(readRequired("RC_E2E_CHAT_ID")),
     recordCount: readRecordCount(),
-    cleanup: readBooleanEnv("RC_E2E_CLEANUP", true),
+    cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     wsTimeoutMs: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
   };
   if (missing.length > 0) {


### PR DESCRIPTION
## Summary
- Default RingCentral live smoke cleanup is now off for PR, push, manual default, and local runs without `RC_E2E_CLEANUP`.
- Manual workflow `cleanup=true` and local `RC_E2E_CLEANUP=true` still delete test messages.
- Step Summary now includes `cleanup=false` even on early configuration failures.
- Live smoke now covers real threaded reply: owner root message, bot threaded reply via OpenClaw `sendMessage`, owner reads reply with thread metadata.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ringcentral-live-smoke.yml"); puts "yaml ok"'`
- `pnpm typecheck`
- `pnpm test` -> 168 passed, 1 skipped
- Missing-secret failure summary verified locally with default `cleanup=false`
- Local live smoke with `~/.secrets.env` and `RC_E2E_CLEANUP=true` -> 1 passed
- Step Summary verified `owner_thread_root_send`, `bot_thread_reply`, `owner_read_thread_reply`, and `thread_metadata=true`

## Note
- Default live smoke remains cleanup-off by design so channel messages are auditable. Local verification used `RC_E2E_CLEANUP=true` to avoid leaving extra test messages.
