### PR TITLE
Add RingCentral Adaptive Cards support

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -79,7 +79,8 @@
     "actions.channelInfo": { "label": "Channel Info" },
     "actions.tasks": { "label": "Tasks" },
     "actions.events": { "label": "Events" },
-    "actions.notes": { "label": "Notes" }
+    "actions.notes": { "label": "Notes" },
+    "actions.adaptiveCards": { "label": "Adaptive Cards" }
   },
   "configSchema": {
     "type": "object",
@@ -165,7 +166,8 @@
           "channelInfo": { "type": "boolean" },
           "tasks": { "type": "boolean" },
           "events": { "type": "boolean" },
-          "notes": { "type": "boolean" }
+          "notes": { "type": "boolean" },
+          "adaptiveCards": { "type": "boolean" }
         }
       }
     }

--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -28,6 +28,10 @@ vi.mock("./actions.js", () => ({
   actionUpdateNote: vi.fn().mockResolvedValue({ success: true }),
   actionDeleteNote: vi.fn().mockResolvedValue({ success: true }),
   actionPublishNote: vi.fn().mockResolvedValue({ success: true }),
+  actionCreateAdaptiveCard: vi.fn().mockResolvedValue({ success: true, cardId: "ac1" }),
+  actionGetAdaptiveCard: vi.fn().mockResolvedValue({ success: true, card: { id: "ac1", type: "AdaptiveCard" } }),
+  actionUpdateAdaptiveCard: vi.fn().mockResolvedValue({ success: true }),
+  actionDeleteAdaptiveCard: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 const mockClient = {} as any;
@@ -45,8 +49,9 @@ describe("getEnabledActions", () => {
     expect(all).toContain("create-task");
     expect(all).toContain("create-event");
     expect(all).toContain("create-note");
+    expect(all).toContain("create-adaptive-card");
     expect(all).toContain("confirm-action");
-    expect(all.length).toBe(20);
+    expect(all.length).toBe(24);
   });
 
   it("excludes messages when disabled", () => {
@@ -74,6 +79,12 @@ describe("getEnabledActions", () => {
     const result = getEnabledActions({ notes: false });
     expect(result).not.toContain("create-note");
     expect(result).not.toContain("publish-note");
+  });
+
+  it("excludes adaptive cards when disabled", () => {
+    const result = getEnabledActions({ adaptiveCards: false });
+    expect(result).not.toContain("create-adaptive-card");
+    expect(result).not.toContain("delete-adaptive-card");
   });
 
   it("excludes channelInfo when disabled", () => {
@@ -133,6 +144,29 @@ describe("handleAction", () => {
     expect(actions.actionPublishNote).toHaveBeenCalledWith(mockClient, "n1");
   });
 
+  it("routes create-adaptive-card with full card payload", async () => {
+    const card = { type: "AdaptiveCard", version: "1.3", body: [] };
+    await handleAction(mockClient, "create-adaptive-card", { chatId: "c1", card });
+    expect(actions.actionCreateAdaptiveCard).toHaveBeenCalledWith(mockClient, "c1", card);
+  });
+
+  it("routes create-adaptive-card from text", async () => {
+    await handleAction(mockClient, "create-adaptive-card", { chatId: "c1", text: "hello card" });
+    expect(actions.actionCreateAdaptiveCard).toHaveBeenCalledWith(
+      mockClient,
+      "c1",
+      expect.objectContaining({
+        type: "AdaptiveCard",
+        body: [expect.objectContaining({ text: "hello card" })],
+      }),
+    );
+  });
+
+  it("routes get-adaptive-card", async () => {
+    await handleAction(mockClient, "get-adaptive-card", { cardId: "ac1" });
+    expect(actions.actionGetAdaptiveCard).toHaveBeenCalledWith(mockClient, "ac1");
+  });
+
   it("supports param aliases (chat_id, post_id, messageId)", async () => {
     await handleAction(mockClient, "send-message", { chat_id: "c2", message: "yo" });
     expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "c2", "yo");
@@ -163,6 +197,10 @@ describe("handleAction", () => {
     result = await handleAction(mockClient, "delete-note", { id: "n99" });
     await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
     expect(actions.actionDeleteNote).toHaveBeenCalledWith(mockClient, "n99");
+
+    result = await handleAction(mockClient, "delete-adaptive-card", { id: "ac99" });
+    await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
+    expect(actions.actionDeleteAdaptiveCard).toHaveBeenCalledWith(mockClient, "ac99");
   });
 
   it("returns error for unknown action", async () => {
@@ -263,6 +301,11 @@ describe("handleAction", () => {
 
     it("requires confirmation for update-event", async () => {
       const result = await handleAction(mockClient, "update-event", { eventId: "e1", title: "new" }) as any;
+      expect(result.requiresConfirmation).toBe(true);
+    });
+
+    it("requires confirmation for update-adaptive-card", async () => {
+      const result = await handleAction(mockClient, "update-adaptive-card", { cardId: "ac1", text: "new" }) as any;
       expect(result.requiresConfirmation).toBe(true);
     });
   });

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -7,6 +7,7 @@ import type {
   ChannelMessageActionName,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { RingCentralClient } from "./client.js";
+import type { CreateAdaptiveCardRequest } from "./types.js";
 import { createBotClient, createOwnerClient } from "./client.js";
 import { getRcConfig, hasOwnerCredentials, isAccountConfigured, resolveAccount } from "./accounts.js";
 import * as actions from "./actions.js";
@@ -22,6 +23,10 @@ const CHAT_SCOPED_ACTIONS = new Set<ActionName>([
   "create-task",
   "list-notes",
   "create-note",
+  "create-adaptive-card",
+  "get-adaptive-card",
+  "update-adaptive-card",
+  "delete-adaptive-card",
 ]);
 
 const PROTECTED_ACTIONS = new Set<ActionName>([
@@ -33,6 +38,8 @@ const PROTECTED_ACTIONS = new Set<ActionName>([
   "update-event",
   "update-note",
   "edit-message",
+  "update-adaptive-card",
+  "delete-adaptive-card",
 ]);
 
 const PENDING_ACTION_TTL_MS = 2 * 60 * 1000; // 2 minutes
@@ -61,7 +68,16 @@ function generateNonce(): string {
 }
 
 function buildConfirmationSummary(action: ActionName, params: Record<string, unknown>): string {
-  const id = String(params.taskId ?? params.eventId ?? params.noteId ?? params.postId ?? params.id ?? params.messageId ?? "");
+  const id = String(
+    params.taskId ??
+      params.eventId ??
+      params.noteId ??
+      params.cardId ??
+      params.postId ??
+      params.id ??
+      params.messageId ??
+      "",
+  );
   return `Confirm ${action}${id ? ` (id: ${id})` : ""}?`;
 }
 
@@ -85,6 +101,10 @@ export type ActionName =
   | "update-note"
   | "delete-note"
   | "publish-note"
+  | "create-adaptive-card"
+  | "get-adaptive-card"
+  | "update-adaptive-card"
+  | "delete-adaptive-card"
   | "confirm-action";
 
 export interface ActionConfig {
@@ -93,6 +113,7 @@ export interface ActionConfig {
   tasks?: boolean;
   events?: boolean;
   notes?: boolean;
+  adaptiveCards?: boolean;
 }
 
 export function getEnabledActions(config: ActionConfig = {}): ActionName[] {
@@ -111,6 +132,14 @@ export function getEnabledActions(config: ActionConfig = {}): ActionName[] {
   }
   if (config.notes !== false) {
     all.push("list-notes", "create-note", "update-note", "delete-note", "publish-note");
+  }
+  if (config.adaptiveCards !== false) {
+    all.push(
+      "create-adaptive-card",
+      "get-adaptive-card",
+      "update-adaptive-card",
+      "delete-adaptive-card",
+    );
   }
   all.push("confirm-action");
   return all;
@@ -137,6 +166,30 @@ function agentToolResult(details: unknown): AgentToolResult<unknown> {
 function readTargetChatId(params: Record<string, unknown>): string {
   const target = String(params.to ?? params.chatId ?? params.chat_id ?? "");
   return extractChatId(target) ?? target;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readAdaptiveCardPayload(params: Record<string, unknown>): CreateAdaptiveCardRequest {
+  if (isRecord(params.card)) {
+    return { ...params.card, type: "AdaptiveCard" } as CreateAdaptiveCardRequest;
+  }
+  if (Array.isArray(params.body)) {
+    return {
+      type: "AdaptiveCard",
+      body: params.body,
+      version: String(params.version ?? "1.3"),
+      ...(Array.isArray(params.actions) ? { actions: params.actions } : {}),
+    };
+  }
+  const text = String(params.text ?? params.title ?? "RingCentral Adaptive Card");
+  return {
+    type: "AdaptiveCard",
+    version: "1.3",
+    body: [{ type: "TextBlock", text, wrap: true }],
+  };
 }
 
 function createActionClient(cfg: unknown): RingCentralClient {
@@ -321,6 +374,20 @@ async function executeAction(
     case "publish-note": {
       const noteId = String(params.noteId ?? params.id ?? "");
       return actions.actionPublishNote(client, noteId);
+    }
+    case "create-adaptive-card":
+      return actions.actionCreateAdaptiveCard(client, chatId, readAdaptiveCardPayload(params));
+    case "get-adaptive-card": {
+      const cardId = String(params.cardId ?? params.id ?? "");
+      return actions.actionGetAdaptiveCard(client, cardId);
+    }
+    case "update-adaptive-card": {
+      const cardId = String(params.cardId ?? params.id ?? "");
+      return actions.actionUpdateAdaptiveCard(client, cardId, readAdaptiveCardPayload(params));
+    }
+    case "delete-adaptive-card": {
+      const cardId = String(params.cardId ?? params.id ?? "");
+      return actions.actionDeleteAdaptiveCard(client, cardId);
     }
     default:
       return { success: false, error: `Unknown action: ${action}` };

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,6 +2,7 @@
 // Used by actions-adapter.ts to handle OpenClaw agent tool calls.
 
 import type { RingCentralClient } from "./client.js";
+import type { CreateAdaptiveCardRequest } from "./types.js";
 
 export async function actionSendMessage(
   client: RingCentralClient,
@@ -263,6 +264,56 @@ export async function actionPublishNote(
 ): Promise<{ success: boolean; error?: string }> {
   try {
     await client.publishNote(noteId);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionCreateAdaptiveCard(
+  client: RingCentralClient,
+  chatId: string,
+  card: CreateAdaptiveCardRequest,
+): Promise<{ success: boolean; cardId?: string; error?: string }> {
+  try {
+    const created = await client.createAdaptiveCard(chatId, card);
+    return { success: true, cardId: created.id };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionGetAdaptiveCard(
+  client: RingCentralClient,
+  cardId: string,
+): Promise<{ success: boolean; card?: { id: string; type: string }; error?: string }> {
+  try {
+    const card = await client.getAdaptiveCard(cardId);
+    return { success: true, card: { id: card.id, type: card.type } };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionUpdateAdaptiveCard(
+  client: RingCentralClient,
+  cardId: string,
+  card: CreateAdaptiveCardRequest,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await client.updateAdaptiveCard(cardId, card);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionDeleteAdaptiveCard(
+  client: RingCentralClient,
+  cardId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await client.deleteAdaptiveCard(cardId);
     return { success: true };
   } catch (err) {
     return { success: false, error: String(err) };

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -241,6 +241,33 @@ describe("RingCentralClient", () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ id: "ac1", type: "AdaptiveCard" }));
       const card = await client.createAdaptiveCard("c1", { type: "AdaptiveCard", body: [], version: "1.3" });
       expect(card.id).toBe("ac1");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.example.com/team-messaging/v1/chats/c1/adaptive-cards",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("get/update/delete AdaptiveCard", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "ac1", type: "AdaptiveCard" }));
+      await expect(client.getAdaptiveCard("ac1")).resolves.toMatchObject({ id: "ac1" });
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/adaptive-cards/ac1",
+        expect.objectContaining({ method: "GET" }),
+      );
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "ac1", type: "AdaptiveCard" }));
+      await client.updateAdaptiveCard("ac1", { type: "AdaptiveCard", body: [], version: "1.3" });
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/adaptive-cards/ac1",
+        expect.objectContaining({ method: "PUT" }),
+      );
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve("") });
+      await expect(client.deleteAdaptiveCard("ac1")).resolves.toBeUndefined();
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/adaptive-cards/ac1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 });

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -48,7 +48,7 @@ describe("ringCentralConfigSchema", () => {
       textChunkLimit: 2000,
       allowBots: false,
       workspace: "/tmp/workspace",
-      actions: { messages: true, channelInfo: true, tasks: true, events: true, notes: true },
+      actions: { messages: true, channelInfo: true, tasks: true, events: true, notes: true, adaptiveCards: true },
     });
     expect(result.success).toBe(true);
   });
@@ -92,7 +92,7 @@ describe("ringCentralConfigSchema", () => {
 
   it("accepts actions with all false", () => {
     const result = ringCentralConfigSchema.safeParse({
-      actions: { messages: false, channelInfo: false, tasks: false, events: false, notes: false },
+      actions: { messages: false, channelInfo: false, tasks: false, events: false, notes: false, adaptiveCards: false },
     });
     expect(result.success).toBe(true);
   });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -33,6 +33,7 @@ const actionsSchema = z.object({
   tasks: z.boolean().optional(),
   events: z.boolean().optional(),
   notes: z.boolean().optional(),
+  adaptiveCards: z.boolean().optional(),
 });
 
 export const ringCentralConfigSchema = z.object({

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -10,7 +10,7 @@ import { createRingCentralHistoryTool } from "../history-tool.js";
 import { RingCentralWebSocketMonitor } from "../monitor.js";
 import { sendMessage } from "../send.js";
 import { extractChatId } from "../targets.js";
-import type { ExtensionInfo, Post } from "../types.js";
+import type { CreateAdaptiveCardRequest, ExtensionInfo, Post } from "../types.js";
 
 const required = readBooleanEnv("RC_E2E_REQUIRED", false);
 const enabled = readBooleanEnv("RC_E2E_ENABLED", false);
@@ -31,6 +31,7 @@ liveDescribe("RingCentral live smoke", () => {
     let ownerClient: RingCentralClient | undefined;
     const createdBotPostIds: string[] = [];
     const createdOwnerPostIds: string[] = [];
+    const createdBotAdaptiveCardIds: string[] = [];
 
     try {
       env = readLiveEnv();
@@ -85,6 +86,13 @@ liveDescribe("RingCentral live smoke", () => {
         createdBotPostIds,
         createdOwnerPostIds,
       });
+      await runAdaptiveCardScenario({
+        env,
+        botClient,
+        ownerClient,
+        createdBotPostIds,
+        createdBotAdaptiveCardIds,
+      });
     } catch (err) {
       summary.fail(err);
       throw err;
@@ -98,6 +106,11 @@ liveDescribe("RingCentral live smoke", () => {
             ownerClient,
             botPostIds: createdBotPostIds,
             ownerPostIds: createdOwnerPostIds,
+          });
+          await cleanupAdaptiveCards({
+            cleanup: env.cleanup,
+            botClient,
+            adaptiveCardIds: createdBotAdaptiveCardIds,
           });
         }
       } finally {
@@ -128,6 +141,7 @@ interface LiveClients {
   ownerClient: RingCentralClient;
   createdBotPostIds: string[];
   createdOwnerPostIds?: string[];
+  createdBotAdaptiveCardIds?: string[];
 }
 
 type SummaryDetail = boolean | number | string;
@@ -386,6 +400,35 @@ async function runThreadedReplyScenario(
   logSafe("owner_read_thread_reply", { owner_read_found: true, thread_metadata: true });
 }
 
+async function runAdaptiveCardScenario(
+  params: LiveClients & {
+    createdBotAdaptiveCardIds: string[];
+  },
+): Promise<void> {
+  const initialText = buildUniqueText("adaptive-card");
+  const updatedText = buildUniqueText("adaptive-card-updated");
+  const card = buildAdaptiveCard(initialText);
+
+  const created = await liveStep("adaptive_card_create", () =>
+    params.botClient.createAdaptiveCard(params.env.chatId, card),
+  );
+  assertLive(!!created.id, "adaptive_card_create");
+  params.createdBotAdaptiveCardIds.push(created.id);
+  logSafe("adaptive_card_create", { created: true });
+
+  const read = await liveStep("adaptive_card_get", () =>
+    params.botClient.getAdaptiveCard(created.id),
+  );
+  assertLive(read.id === created.id, "adaptive_card_get");
+  logSafe("adaptive_card_get", { found: true });
+
+  const updated = await liveStep("adaptive_card_update", () =>
+    params.botClient.updateAdaptiveCard(created.id, buildAdaptiveCard(updatedText)),
+  );
+  assertLive(updated.id === created.id, "adaptive_card_update");
+  logSafe("adaptive_card_update", { updated: true });
+}
+
 function readLiveEnv(): LiveEnv {
   const missing: string[] = [];
   const readRequired = (name: string) => {
@@ -454,6 +497,15 @@ function buildUniqueText(label: string): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function buildAdaptiveCard(text: string): CreateAdaptiveCardRequest {
+  return {
+    type: "AdaptiveCard",
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    version: "1.3",
+    body: [{ type: "TextBlock", text, wrap: true }],
+  };
 }
 
 async function waitForPost(
@@ -623,6 +675,29 @@ async function cleanupPosts(params: {
   logSafe("cleanup", {
     cleanup_bot_post: cleanupBotPost,
     cleanup_owner_post: cleanupOwnerPost,
+  });
+}
+
+async function cleanupAdaptiveCards(params: {
+  cleanup: boolean;
+  botClient: RingCentralClient;
+  adaptiveCardIds: string[];
+}): Promise<void> {
+  if (!params.cleanup) {
+    logSafe("adaptive_card_cleanup", { enabled: false });
+    return;
+  }
+
+  let cleanupAdaptiveCards = true;
+  for (const cardId of params.adaptiveCardIds.reverse()) {
+    try {
+      await params.botClient.deleteAdaptiveCard(cardId);
+    } catch {
+      cleanupAdaptiveCards = false;
+    }
+  }
+  logSafe("adaptive_card_cleanup", {
+    cleanup_adaptive_cards: cleanupAdaptiveCards,
   });
 }
 

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -502,7 +502,7 @@ function buildUniqueText(label: string): string {
 function buildAdaptiveCard(text: string): CreateAdaptiveCardRequest {
   return {
     type: "AdaptiveCard",
-    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    $schema: "https://adaptivecards.io/schemas/adaptive-card.json",
     version: "1.3",
     body: [{ type: "TextBlock", text, wrap: true }],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,7 @@ export interface RingCentralConfig {
     tasks?: boolean;
     events?: boolean;
     notes?: boolean;
+    adaptiveCards?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary
- add RingCentral Adaptive Card create/get/update/delete support
- expose OpenClaw action config and action adapter routing for adaptive cards
- extend live smoke coverage with adaptive_card_create/get/update and cleanup

## Live verification
- verified with ~/.secrets.env against RC_E2E_CHAT_ID
- create/get/update/delete work with masked logs
- list endpoint was probed and returned HTTP 404, so list support is intentionally omitted

## Tests
- pnpm typecheck
- pnpm test
- RC_E2E_ENABLED=true RC_E2E_CLEANUP=true pnpm test:live:ringcentral