### PR TITLE
Add RingCentral notes support

### DIFF
--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -25,6 +25,7 @@ vi.mock("./actions.js", () => ({
   actionDeleteEvent: vi.fn().mockResolvedValue({ success: true }),
   actionListNotes: vi.fn().mockResolvedValue({ success: true, notes: [] }),
   actionCreateNote: vi.fn().mockResolvedValue({ success: true, noteId: "n1" }),
+  actionGetNote: vi.fn().mockResolvedValue({ success: true, note: { id: "n1", title: "Note" } }),
   actionUpdateNote: vi.fn().mockResolvedValue({ success: true }),
   actionDeleteNote: vi.fn().mockResolvedValue({ success: true }),
   actionPublishNote: vi.fn().mockResolvedValue({ success: true }),
@@ -45,8 +46,9 @@ describe("getEnabledActions", () => {
     expect(all).toContain("create-task");
     expect(all).toContain("create-event");
     expect(all).toContain("create-note");
+    expect(all).toContain("get-note");
     expect(all).toContain("confirm-action");
-    expect(all.length).toBe(20);
+    expect(all.length).toBe(21);
   });
 
   it("excludes messages when disabled", () => {
@@ -73,6 +75,7 @@ describe("getEnabledActions", () => {
   it("excludes notes when disabled", () => {
     const result = getEnabledActions({ notes: false });
     expect(result).not.toContain("create-note");
+    expect(result).not.toContain("get-note");
     expect(result).not.toContain("publish-note");
   });
 
@@ -125,7 +128,17 @@ describe("handleAction", () => {
 
   it("routes create-note with body", async () => {
     await handleAction(mockClient, "create-note", { chatId: "c1", title: "Note", body: "content" });
-    expect(actions.actionCreateNote).toHaveBeenCalledWith(mockClient, "c1", "Note", "content");
+    expect(actions.actionCreateNote).toHaveBeenCalledWith(mockClient, "c1", "Note", "content", false);
+  });
+
+  it("routes create-note with explicit publish", async () => {
+    await handleAction(mockClient, "create-note", { chatId: "c1", title: "Note", publish: true });
+    expect(actions.actionCreateNote).toHaveBeenCalledWith(mockClient, "c1", "Note", undefined, true);
+  });
+
+  it("routes get-note", async () => {
+    await handleAction(mockClient, "get-note", { noteId: "n1" });
+    expect(actions.actionGetNote).toHaveBeenCalledWith(mockClient, "n1");
   });
 
   it("routes publish-note", async () => {
@@ -200,6 +213,20 @@ describe("handleAction", () => {
       expect(actions.actionSendMessage).toHaveBeenCalledWith(mockClient, "any-chat", "hi");
     });
 
+    it("blocks scoped note actions when chatId differs from sessionChatId", async () => {
+      const result = await handleAction(
+        mockClient,
+        "publish-note",
+        { chatId: "evil-chat", noteId: "n1" },
+        "session-chat",
+      );
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("Action scope violation"),
+      });
+      expect(actions.actionPublishNote).not.toHaveBeenCalled();
+    });
+
     it("allows non-chat-scoped actions with different chatId", async () => {
       const result = await handleAction(
         mockClient,
@@ -264,6 +291,16 @@ describe("handleAction", () => {
     it("requires confirmation for update-event", async () => {
       const result = await handleAction(mockClient, "update-event", { eventId: "e1", title: "new" }) as any;
       expect(result.requiresConfirmation).toBe(true);
+    });
+
+    it("requires confirmation for update-note and preserves body updates", async () => {
+      const result = await handleAction(mockClient, "update-note", { noteId: "n1", title: "new", body: "body" }) as any;
+      expect(result.requiresConfirmation).toBe(true);
+      await handleAction(mockClient, "confirm-action", { nonce: result.confirmationId });
+      expect(actions.actionUpdateNote).toHaveBeenCalledWith(mockClient, "n1", {
+        title: "new",
+        body: "body",
+      });
     });
   });
 });

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -22,6 +22,10 @@ const CHAT_SCOPED_ACTIONS = new Set<ActionName>([
   "create-task",
   "list-notes",
   "create-note",
+  "get-note",
+  "update-note",
+  "delete-note",
+  "publish-note",
 ]);
 
 const PROTECTED_ACTIONS = new Set<ActionName>([
@@ -82,6 +86,7 @@ export type ActionName =
   | "delete-event"
   | "list-notes"
   | "create-note"
+  | "get-note"
   | "update-note"
   | "delete-note"
   | "publish-note"
@@ -110,7 +115,7 @@ export function getEnabledActions(config: ActionConfig = {}): ActionName[] {
     all.push("list-events", "create-event", "update-event", "delete-event");
   }
   if (config.notes !== false) {
-    all.push("list-notes", "create-note", "update-note", "delete-note", "publish-note");
+    all.push("list-notes", "create-note", "get-note", "update-note", "delete-note", "publish-note");
   }
   all.push("confirm-action");
   return all;
@@ -307,12 +312,19 @@ async function executeAction(
     case "create-note": {
       const title = String(params.title ?? "");
       const body = params.body ? String(params.body) : undefined;
-      return actions.actionCreateNote(client, chatId, title, body);
+      const publish = Boolean(params.publish ?? params.publishImmediately);
+      return actions.actionCreateNote(client, chatId, title, body, publish);
+    }
+    case "get-note": {
+      const noteId = String(params.noteId ?? params.id ?? "");
+      return actions.actionGetNote(client, noteId);
     }
     case "update-note": {
       const noteId = String(params.noteId ?? params.id ?? "");
-      const title = String(params.title ?? "");
-      return actions.actionUpdateNote(client, noteId, title);
+      return actions.actionUpdateNote(client, noteId, {
+        title: params.title ? String(params.title) : undefined,
+        body: params.body ? String(params.body) : undefined,
+      });
     }
     case "delete-note": {
       const noteId = String(params.noteId ?? params.id ?? "");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,6 +2,7 @@
 // Used by actions-adapter.ts to handle OpenClaw agent tool calls.
 
 import type { RingCentralClient } from "./client.js";
+import type { CreateNoteRequest } from "./types.js";
 
 export async function actionSendMessage(
   client: RingCentralClient,
@@ -222,11 +223,29 @@ export async function actionCreateNote(
   chatId: string,
   title: string,
   body?: string,
-): Promise<{ success: boolean; noteId?: string; error?: string }> {
+  publish = false,
+): Promise<{ success: boolean; noteId?: string; published?: boolean; error?: string }> {
   try {
     const note = await client.createNote(chatId, { title, body });
-    await client.publishNote(note.id);
-    return { success: true, noteId: note.id };
+    if (publish) {
+      await client.publishNote(note.id);
+    }
+    return { success: true, noteId: note.id, published: publish };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionGetNote(
+  client: RingCentralClient,
+  noteId: string,
+): Promise<{ success: boolean; note?: { id: string; title: string; body?: string; status?: string }; error?: string }> {
+  try {
+    const note = await client.getNote(noteId);
+    return {
+      success: true,
+      note: { id: note.id, title: note.title, body: note.body, status: note.status },
+    };
   } catch (err) {
     return { success: false, error: String(err) };
   }
@@ -235,10 +254,10 @@ export async function actionCreateNote(
 export async function actionUpdateNote(
   client: RingCentralClient,
   noteId: string,
-  title: string,
+  updates: Partial<CreateNoteRequest>,
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    await client.updateNote(noteId, { title });
+    await client.updateNote(noteId, updates);
     return { success: true };
   } catch (err) {
     return { success: false, error: String(err) };

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -224,13 +224,54 @@ describe("RingCentralClient", () => {
   describe("notes", () => {
     const client = createBotClient("https://api.example.com", "tok");
 
-    it("createNote and publishNote", async () => {
+    it("listNotes", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ records: [{ id: "n1", title: "Note" }] }));
+      const result = await client.listNotes("c1");
+      expect(result.records).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.example.com/team-messaging/v1/chats/c1/notes?recordCount=50",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("createNote and publishNote use verified endpoints", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ id: "n1", title: "Note" }));
       const note = await client.createNote("c1", { title: "Note" });
       expect(note.id).toBe("n1");
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/chats/c1/notes",
+        expect.objectContaining({ method: "POST" }),
+      );
 
       mockFetch.mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve("") });
       await expect(client.publishNote("n1")).resolves.toBeUndefined();
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/notes/n1/publish",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("get/update/delete note use note-scoped endpoints", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "n1", title: "Note" }));
+      await expect(client.getNote("n1")).resolves.toMatchObject({ id: "n1" });
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/notes/n1",
+        expect.objectContaining({ method: "GET" }),
+      );
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "n1", title: "Updated" }));
+      await client.updateNote("n1", { title: "Updated", body: "<b>Body</b>" });
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/notes/n1",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve("") });
+      await expect(client.deleteNote("n1")).resolves.toBeUndefined();
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://api.example.com/team-messaging/v1/notes/n1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -31,6 +31,7 @@ liveDescribe("RingCentral live smoke", () => {
     let ownerClient: RingCentralClient | undefined;
     const createdBotPostIds: string[] = [];
     const createdOwnerPostIds: string[] = [];
+    const createdOwnerNoteIds: string[] = [];
 
     try {
       env = readLiveEnv();
@@ -85,6 +86,13 @@ liveDescribe("RingCentral live smoke", () => {
         createdBotPostIds,
         createdOwnerPostIds,
       });
+      await runNoteScenario({
+        env,
+        botClient,
+        ownerClient,
+        createdBotPostIds,
+        createdOwnerNoteIds,
+      });
     } catch (err) {
       summary.fail(err);
       throw err;
@@ -98,6 +106,11 @@ liveDescribe("RingCentral live smoke", () => {
             ownerClient,
             botPostIds: createdBotPostIds,
             ownerPostIds: createdOwnerPostIds,
+          });
+          await cleanupNotes({
+            cleanup: env.cleanup,
+            ownerClient,
+            noteIds: createdOwnerNoteIds,
           });
         }
       } finally {
@@ -128,6 +141,7 @@ interface LiveClients {
   ownerClient: RingCentralClient;
   createdBotPostIds: string[];
   createdOwnerPostIds?: string[];
+  createdOwnerNoteIds?: string[];
 }
 
 type SummaryDetail = boolean | number | string;
@@ -386,6 +400,41 @@ async function runThreadedReplyScenario(
   logSafe("owner_read_thread_reply", { owner_read_found: true, thread_metadata: true });
 }
 
+async function runNoteScenario(
+  params: LiveClients & {
+    createdOwnerNoteIds: string[];
+  },
+): Promise<void> {
+  const title = buildUniqueText("note-title");
+  const updatedTitle = buildUniqueText("note-title-updated");
+  const body = `<strong>${escapeHtml(title)}</strong>`;
+  const updatedBody = `<strong>${escapeHtml(updatedTitle)}</strong>`;
+
+  const created = await liveStep("note_create", () =>
+    params.ownerClient.createNote(params.env.chatId, { title, body }),
+  );
+  assertLive(!!created.id, "note_create");
+  params.createdOwnerNoteIds.push(created.id);
+  logSafe("note_create", { created: true });
+
+  const read = await liveStep("note_get", () =>
+    params.ownerClient.getNote(created.id),
+  );
+  assertLive(read.id === created.id, "note_get");
+  logSafe("note_get", { found: true });
+
+  const updated = await liveStep("note_update", () =>
+    params.ownerClient.updateNote(created.id, { title: updatedTitle, body: updatedBody }),
+  );
+  assertLive(updated.id === created.id, "note_update");
+  logSafe("note_update", { updated: true });
+
+  await liveStep("note_publish", () =>
+    params.ownerClient.publishNote(created.id),
+  );
+  logSafe("note_publish", { published: true });
+}
+
 function readLiveEnv(): LiveEnv {
   const missing: string[] = [];
   const readRequired = (name: string) => {
@@ -454,6 +503,13 @@ function buildUniqueText(label: string): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 async function waitForPost(
@@ -623,6 +679,29 @@ async function cleanupPosts(params: {
   logSafe("cleanup", {
     cleanup_bot_post: cleanupBotPost,
     cleanup_owner_post: cleanupOwnerPost,
+  });
+}
+
+async function cleanupNotes(params: {
+  cleanup: boolean;
+  ownerClient: RingCentralClient;
+  noteIds: string[];
+}): Promise<void> {
+  if (!params.cleanup) {
+    logSafe("note_cleanup", { enabled: false });
+    return;
+  }
+
+  let cleanupNotes = true;
+  for (const noteId of params.noteIds.reverse()) {
+    try {
+      await params.ownerClient.deleteNote(noteId);
+    } catch {
+      cleanupNotes = false;
+    }
+  }
+  logSafe("note_cleanup", {
+    cleanup_notes: cleanupNotes,
   });
 }
 


### PR DESCRIPTION
## Summary
- add RingCentral Notes actions for create/get/update/delete/publish
- keep note creation as draft by default; publish is explicit
- extend live smoke with owner note create/get/update/publish and optional cleanup

## Live API verification
- verified chat-scoped create/list and global get/update/publish/delete with RC_E2E_CHAT_ID
- owner credentials are the reliable write path; bot token note update was not used for tool semantics

## Test plan
- pnpm typecheck
- pnpm test
- RC_E2E_ENABLED=true RC_E2E_CLEANUP=true pnpm test:live:ringcentral