### PR TITLE
Add RingCentral calendar event support

### DIFF
--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -21,6 +21,7 @@ vi.mock("./actions.js", () => ({
   actionDeleteTask: vi.fn().mockResolvedValue({ success: true }),
   actionListEvents: vi.fn().mockResolvedValue({ success: true, events: [] }),
   actionCreateEvent: vi.fn().mockResolvedValue({ success: true, eventId: "e1" }),
+  actionGetEvent: vi.fn().mockResolvedValue({ success: true, event: { id: "e1" } }),
   actionUpdateEvent: vi.fn().mockResolvedValue({ success: true }),
   actionDeleteEvent: vi.fn().mockResolvedValue({ success: true }),
   actionListNotes: vi.fn().mockResolvedValue({ success: true, notes: [] }),
@@ -44,9 +45,10 @@ describe("getEnabledActions", () => {
     expect(all).toContain("channel-info");
     expect(all).toContain("create-task");
     expect(all).toContain("create-event");
+    expect(all).toContain("get-event");
     expect(all).toContain("create-note");
     expect(all).toContain("confirm-action");
-    expect(all.length).toBe(20);
+    expect(all.length).toBe(21);
   });
 
   it("excludes messages when disabled", () => {
@@ -119,8 +121,13 @@ describe("handleAction", () => {
   });
 
   it("routes create-event", async () => {
-    await handleAction(mockClient, "create-event", { title: "Meet", startTime: "2026-01-01T10:00:00Z", endTime: "2026-01-01T11:00:00Z" });
-    expect(actions.actionCreateEvent).toHaveBeenCalledWith(mockClient, "Meet", "2026-01-01T10:00:00Z", "2026-01-01T11:00:00Z");
+    await handleAction(mockClient, "create-event", { chatId: "c1", title: "Meet", startTime: "2026-01-01T10:00:00Z", endTime: "2026-01-01T11:00:00Z" });
+    expect(actions.actionCreateEvent).toHaveBeenCalledWith(mockClient, "c1", "Meet", "2026-01-01T10:00:00Z", "2026-01-01T11:00:00Z", undefined);
+  });
+
+  it("routes get-event", async () => {
+    await handleAction(mockClient, "get-event", { eventId: "e1" });
+    expect(actions.actionGetEvent).toHaveBeenCalledWith(mockClient, "e1");
   });
 
   it("routes create-note with body", async () => {

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -20,6 +20,11 @@ const CHAT_SCOPED_ACTIONS = new Set<ActionName>([
   "channel-info",
   "list-tasks",
   "create-task",
+  "list-events",
+  "create-event",
+  "get-event",
+  "update-event",
+  "delete-event",
   "list-notes",
   "create-note",
 ]);
@@ -78,6 +83,7 @@ export type ActionName =
   | "delete-task"
   | "list-events"
   | "create-event"
+  | "get-event"
   | "update-event"
   | "delete-event"
   | "list-notes"
@@ -107,7 +113,7 @@ export function getEnabledActions(config: ActionConfig = {}): ActionName[] {
     all.push("list-tasks", "create-task", "update-task", "complete-task", "delete-task");
   }
   if (config.events !== false) {
-    all.push("list-events", "create-event", "update-event", "delete-event");
+    all.push("list-events", "create-event", "get-event", "update-event", "delete-event");
   }
   if (config.notes !== false) {
     all.push("list-notes", "create-note", "update-note", "delete-note", "publish-note");
@@ -283,19 +289,25 @@ async function executeAction(
       return actions.actionDeleteTask(client, taskId);
     }
     case "list-events":
-      return actions.actionListEvents(client);
+      return actions.actionListEvents(client, chatId);
     case "create-event": {
       const title = String(params.title ?? "");
       const startTime = String(params.startTime ?? params.start ?? "");
       const endTime = String(params.endTime ?? params.end ?? "");
-      return actions.actionCreateEvent(client, title, startTime, endTime);
+      const description = params.description ? String(params.description) : undefined;
+      return actions.actionCreateEvent(client, chatId, title, startTime, endTime, description);
+    }
+    case "get-event": {
+      const eventId = String(params.eventId ?? params.id ?? "");
+      return actions.actionGetEvent(client, eventId);
     }
     case "update-event": {
       const eventId = String(params.eventId ?? params.id ?? "");
       return actions.actionUpdateEvent(client, eventId, {
-        title: params.title ? String(params.title) : undefined,
-        startTime: params.startTime ? String(params.startTime) : undefined,
-        endTime: params.endTime ? String(params.endTime) : undefined,
+        title: String(params.title ?? ""),
+        startTime: String(params.startTime ?? params.start ?? ""),
+        endTime: String(params.endTime ?? params.end ?? ""),
+        description: params.description ? String(params.description) : undefined,
       });
     }
     case "delete-event": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -146,9 +146,10 @@ export async function actionDeleteTask(
 
 export async function actionListEvents(
   client: RingCentralClient,
+  chatId: string,
 ): Promise<{ success: boolean; events?: Array<{ id: string; title: string; startTime: string; endTime: string }>; error?: string }> {
   try {
-    const result = await client.listEvents();
+    const result = await client.listEvents(chatId);
     return {
       success: true,
       events: result.records.map((e) => ({
@@ -165,13 +166,35 @@ export async function actionListEvents(
 
 export async function actionCreateEvent(
   client: RingCentralClient,
+  chatId: string,
   title: string,
   startTime: string,
   endTime: string,
+  description?: string,
 ): Promise<{ success: boolean; eventId?: string; error?: string }> {
   try {
-    const event = await client.createEvent({ title, startTime, endTime });
+    const event = await client.createEvent(chatId, { title, startTime, endTime, description });
     return { success: true, eventId: event.id };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function actionGetEvent(
+  client: RingCentralClient,
+  eventId: string,
+): Promise<{ success: boolean; event?: { id: string; title: string; startTime: string; endTime: string }; error?: string }> {
+  try {
+    const event = await client.getEvent(eventId);
+    return {
+      success: true,
+      event: {
+        id: event.id,
+        title: event.title,
+        startTime: event.startTime,
+        endTime: event.endTime,
+      },
+    };
   } catch (err) {
     return { success: false, error: String(err) };
   }
@@ -180,9 +203,12 @@ export async function actionCreateEvent(
 export async function actionUpdateEvent(
   client: RingCentralClient,
   eventId: string,
-  updates: { title?: string; startTime?: string; endTime?: string },
+  updates: { title: string; startTime: string; endTime: string; description?: string },
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    if (!updates.title || !updates.startTime || !updates.endTime) {
+      return { success: false, error: "title, startTime, and endTime are required to update an event" };
+    }
     await client.updateEvent(eventId, updates);
     return { success: true };
   } catch (err) {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -214,10 +214,52 @@ describe("RingCentralClient", () => {
   describe("events", () => {
     const client = createBotClient("https://api.example.com", "tok");
 
-    it("createEvent", async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "e1", title: "Meeting" }));
-      const event = await client.createEvent({ title: "Meeting", startTime: "2026-01-01T10:00:00Z", endTime: "2026-01-01T11:00:00Z" });
+    it("uses group scoped endpoints for list and create events", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ records: [{ id: "e1", title: "Meeting" }] }))
+        .mockResolvedValueOnce(jsonResponse({ id: "e1", title: "Meeting" }));
+
+      const events = await client.listEvents("g1", 10);
+      const event = await client.createEvent("g1", { title: "Meeting", startTime: "2026-01-01T10:00:00Z", endTime: "2026-01-01T11:00:00Z" });
+
+      expect(events.records[0].id).toBe("e1");
       expect(event.id).toBe("e1");
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        "https://api.example.com/team-messaging/v1/groups/g1/events?recordCount=10",
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        "https://api.example.com/team-messaging/v1/groups/g1/events",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("uses global get, put, and delete event endpoints", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "e1", title: "Meeting" }));
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "e1", title: "Updated" }));
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve("") });
+
+      await client.getEvent("e1");
+      await client.updateEvent("e1", { title: "Updated", startTime: "2026-01-01T10:00:00Z", endTime: "2026-01-01T11:00:00Z" });
+      await client.deleteEvent("e1");
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        "https://api.example.com/team-messaging/v1/events/e1",
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        "https://api.example.com/team-messaging/v1/events/e1",
+        expect.objectContaining({ method: "PUT" }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        "https://api.example.com/team-messaging/v1/events/e1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -296,20 +296,23 @@ export class RingCentralClient {
     });
   }
 
-  async listEvents(): Promise<PaginatedRecords<Event>> {
-    return this.request("GET", "/team-messaging/v1/events?recordCount=50");
+  async listEvents(chatId: string, recordCount = 50): Promise<PaginatedRecords<Event>> {
+    return this.request(
+      "GET",
+      `/team-messaging/v1/groups/${RingCentralClient.encodeId(chatId)}/events?recordCount=${Math.trunc(recordCount)}`,
+    );
   }
 
-  async createEvent(req: CreateEventRequest): Promise<Event> {
-    return this.request("POST", "/team-messaging/v1/events", req);
+  async createEvent(chatId: string, req: CreateEventRequest): Promise<Event> {
+    return this.request("POST", `/team-messaging/v1/groups/${RingCentralClient.encodeId(chatId)}/events`, req);
   }
 
   async getEvent(eventId: string): Promise<Event> {
     return this.request("GET", `/team-messaging/v1/events/${RingCentralClient.encodeId(eventId)}`);
   }
 
-  async updateEvent(eventId: string, updates: Partial<CreateEventRequest>): Promise<Event> {
-    return this.request("PATCH", `/team-messaging/v1/events/${RingCentralClient.encodeId(eventId)}`, updates);
+  async updateEvent(eventId: string, updates: CreateEventRequest): Promise<Event> {
+    return this.request("PUT", `/team-messaging/v1/events/${RingCentralClient.encodeId(eventId)}`, updates);
   }
 
   async deleteEvent(eventId: string): Promise<void> {

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -10,7 +10,7 @@ import { createRingCentralHistoryTool } from "../history-tool.js";
 import { RingCentralWebSocketMonitor } from "../monitor.js";
 import { sendMessage } from "../send.js";
 import { extractChatId } from "../targets.js";
-import type { ExtensionInfo, Post } from "../types.js";
+import type { CreateEventRequest, ExtensionInfo, Post } from "../types.js";
 
 const required = readBooleanEnv("RC_E2E_REQUIRED", false);
 const enabled = readBooleanEnv("RC_E2E_ENABLED", false);
@@ -31,6 +31,7 @@ liveDescribe("RingCentral live smoke", () => {
     let ownerClient: RingCentralClient | undefined;
     const createdBotPostIds: string[] = [];
     const createdOwnerPostIds: string[] = [];
+    const createdOwnerEventIds: string[] = [];
 
     try {
       env = readLiveEnv();
@@ -85,6 +86,11 @@ liveDescribe("RingCentral live smoke", () => {
         createdBotPostIds,
         createdOwnerPostIds,
       });
+      await runCalendarEventScenario({
+        env,
+        ownerClient,
+        createdOwnerEventIds,
+      });
     } catch (err) {
       summary.fail(err);
       throw err;
@@ -98,6 +104,11 @@ liveDescribe("RingCentral live smoke", () => {
             ownerClient,
             botPostIds: createdBotPostIds,
             ownerPostIds: createdOwnerPostIds,
+          });
+          await cleanupEvents({
+            cleanup: env.cleanup,
+            ownerClient,
+            eventIds: createdOwnerEventIds,
           });
         }
       } finally {
@@ -386,6 +397,39 @@ async function runThreadedReplyScenario(
   logSafe("owner_read_thread_reply", { owner_read_found: true, thread_metadata: true });
 }
 
+async function runCalendarEventScenario(params: {
+  env: LiveEnv;
+  ownerClient: RingCentralClient;
+  createdOwnerEventIds: string[];
+}): Promise<void> {
+  const eventPayload = buildCalendarEventPayload("calendar-event");
+  const updatedPayload = buildCalendarEventPayload("calendar-event-updated");
+
+  const created = await liveStep("calendar_event_create", () =>
+    params.ownerClient.createEvent(params.env.chatId, eventPayload),
+  );
+  assertLive(!!created.id, "calendar_event_create");
+  const eventId = String(created.id);
+  params.createdOwnerEventIds.push(eventId);
+  logSafe("calendar_event_create", { created: true });
+
+  const listed = await liveStep("calendar_event_list", () =>
+    params.ownerClient.listEvents(params.env.chatId, Math.min(params.env.recordCount, 50)),
+  );
+  assertLive(listed.records.some((event) => event.id === eventId), "calendar_event_list");
+  logSafe("calendar_event_list", { found: true });
+
+  const read = await liveStep("calendar_event_get", () => params.ownerClient.getEvent(eventId));
+  assertLive(read.id === eventId, "calendar_event_get");
+  logSafe("calendar_event_get", { found: true });
+
+  const updated = await liveStep("calendar_event_update", () =>
+    params.ownerClient.updateEvent(eventId, updatedPayload),
+  );
+  assertLive(updated.id === eventId, "calendar_event_update");
+  logSafe("calendar_event_update", { updated: true });
+}
+
 function readLiveEnv(): LiveEnv {
   const missing: string[] = [];
   const readRequired = (name: string) => {
@@ -454,6 +498,18 @@ function buildUniqueText(label: string): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function buildCalendarEventPayload(label: string): CreateEventRequest {
+  const marker = buildUniqueText(label).split("\n")[0] ?? `[openclaw-ringcentral-e2e:${label}:${Date.now()}]`;
+  const start = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const end = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  return {
+    title: marker,
+    startTime: start,
+    endTime: end,
+    description: buildUniqueText(`${label}-description`),
+  };
 }
 
 async function waitForPost(
@@ -624,6 +680,27 @@ async function cleanupPosts(params: {
     cleanup_bot_post: cleanupBotPost,
     cleanup_owner_post: cleanupOwnerPost,
   });
+}
+
+async function cleanupEvents(params: {
+  cleanup: boolean;
+  ownerClient: RingCentralClient;
+  eventIds: string[];
+}): Promise<void> {
+  if (!params.cleanup) {
+    logSafe("calendar_event_cleanup", { enabled: false });
+    return;
+  }
+
+  let cleanupEvents = true;
+  for (const eventId of params.eventIds.reverse()) {
+    try {
+      await params.ownerClient.deleteEvent(eventId);
+    } catch {
+      cleanupEvents = false;
+    }
+  }
+  logSafe("calendar_event_cleanup", { cleanup_events: cleanupEvents });
 }
 
 async function readHistoryToolText(params: {


### PR DESCRIPTION
## Summary
- rewrite calendar event endpoints to match verified RingCentral Team Messaging API behavior
- use group-scoped list/create: /team-messaging/v1/groups/{groupId}/events
- use global get/update/delete with PUT update: /team-messaging/v1/events/{eventId}
- add get-event action and extend live smoke with create/list/get/update plus optional cleanup

## Live API verification
- verified group-scoped list/create and global get/PUT/delete against RC_E2E_CHAT_ID
- previous global /team-messaging/v1/events list/create and PATCH update behavior is replaced

## Test plan
- pnpm typecheck
- pnpm test
- RC_E2E_ENABLED=true RC_E2E_CLEANUP=true pnpm test:live:ringcentral