### PR TITLE
Expose RingCentral artifact tools safely

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,10 +4,76 @@
   "description": "OpenClaw RingCentral Team Messaging channel plugin",
   "channels": ["ringcentral"],
   "contracts": {
-    "tools": ["ringcentral_get_recent_messages"]
+    "tools": [
+      "ringcentral_get_recent_messages",
+      "ringcentral_confirm_artifact_action",
+      "ringcentral_create_adaptive_card",
+      "ringcentral_get_adaptive_card",
+      "ringcentral_update_adaptive_card",
+      "ringcentral_delete_adaptive_card",
+      "ringcentral_list_notes",
+      "ringcentral_create_note",
+      "ringcentral_get_note",
+      "ringcentral_update_note",
+      "ringcentral_delete_note",
+      "ringcentral_publish_note",
+      "ringcentral_list_calendar_events",
+      "ringcentral_create_calendar_event",
+      "ringcentral_get_calendar_event",
+      "ringcentral_update_calendar_event",
+      "ringcentral_delete_calendar_event"
+    ]
   },
   "toolMetadata": {
     "ringcentral_get_recent_messages": {
+      "optional": true
+    },
+    "ringcentral_confirm_artifact_action": {
+      "optional": true
+    },
+    "ringcentral_create_adaptive_card": {
+      "optional": true
+    },
+    "ringcentral_get_adaptive_card": {
+      "optional": true
+    },
+    "ringcentral_update_adaptive_card": {
+      "optional": true
+    },
+    "ringcentral_delete_adaptive_card": {
+      "optional": true
+    },
+    "ringcentral_list_notes": {
+      "optional": true
+    },
+    "ringcentral_create_note": {
+      "optional": true
+    },
+    "ringcentral_get_note": {
+      "optional": true
+    },
+    "ringcentral_update_note": {
+      "optional": true
+    },
+    "ringcentral_delete_note": {
+      "optional": true
+    },
+    "ringcentral_publish_note": {
+      "optional": true
+    },
+    "ringcentral_list_calendar_events": {
+      "optional": true
+    },
+    "ringcentral_create_calendar_event": {
+      "optional": true
+    },
+    "ringcentral_get_calendar_event": {
+      "optional": true
+    },
+    "ringcentral_update_calendar_event": {
+      "optional": true
+    },
+    "ringcentral_delete_calendar_event": {
       "optional": true
     }
   },

--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -382,4 +382,33 @@ describe("ringCentralMessageActions", () => {
     } as any);
     expect(actions.actionReadMessages).toHaveBeenCalledWith(expect.anything(), "c1", 5);
   });
+
+  it("uses bot client for shared actions even when owner credentials are configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ id: 123, extensionNumber: "101", name: "Bot" })),
+      headers: new Map(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = __testing.createActionClient({
+      channels: {
+        ringcentral: {
+          botToken: "bot-token",
+          ownerCredentials: { clientId: "cid", clientSecret: "secret", jwt: "jwt" },
+          server: "https://api.example.com",
+        },
+      },
+    } as any);
+    await client.getExtensionInfo();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/restapi/v1.0/account/~/extension/~",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }),
+    );
+  });
 });

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -8,8 +8,8 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import type { RingCentralClient } from "./client.js";
 import type { CreateAdaptiveCardRequest } from "./types.js";
-import { createBotClient, createOwnerClient } from "./client.js";
-import { getRcConfig, hasOwnerCredentials, isAccountConfigured, resolveAccount } from "./accounts.js";
+import { createBotClient } from "./client.js";
+import { getRcConfig, isAccountConfigured, resolveAccount } from "./accounts.js";
 import * as actions from "./actions.js";
 import { extractChatId } from "./targets.js";
 
@@ -63,6 +63,7 @@ const pendingActions = new Map<string, PendingAction>();
 
 export const __testing = {
   pendingActions,
+  createActionClient,
 };
 
 function cleanExpiredPendingActions(): void {
@@ -206,14 +207,6 @@ function readAdaptiveCardPayload(params: Record<string, unknown>): CreateAdaptiv
 function createActionClient(cfg: unknown): RingCentralClient {
   const rcCfg = getRcConfig(cfg);
   const account = resolveAccount(rcCfg);
-  if (hasOwnerCredentials(account)) {
-    return createOwnerClient(
-      account.server,
-      account.ownerCredentials!.clientId,
-      account.ownerCredentials!.clientSecret,
-      account.ownerCredentials!.jwt,
-    );
-  }
   return createBotClient(account.server, account.botToken);
 }
 

--- a/src/artifact-tools.test.ts
+++ b/src/artifact-tools.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import {
+  __testing,
+  createRingCentralArtifactTools,
+  RINGCENTRAL_ARTIFACT_TOOL_NAMES,
+} from "./artifact-tools.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Map(),
+  };
+}
+
+const cfg = {
+  channels: {
+    ringcentral: {
+      botToken: "bot-token",
+      ownerCredentials: {
+        clientId: "owner-client",
+        clientSecret: "owner-secret",
+        jwt: "owner-jwt",
+      },
+      server: "https://api.example.com",
+      homeChannel: "home-dm",
+    },
+  },
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  __testing.pendingConfirmations.clear();
+});
+
+describe("RingCentral artifact tools", () => {
+  it("registers all optional artifact tools", () => {
+    const tools = createRingCentralArtifactTools(cfg).map((tool) => tool.name);
+    expect(tools).toEqual([...RINGCENTRAL_ARTIFACT_TOOL_NAMES]);
+
+    const manifest = JSON.parse(readFileSync("openclaw.plugin.json", "utf8"));
+    for (const toolName of RINGCENTRAL_ARTIFACT_TOOL_NAMES) {
+      expect(manifest.contracts.tools).toContain(toolName);
+      expect(manifest.toolMetadata[toolName]).toEqual({ optional: true });
+    }
+  });
+
+  it("rejects Adaptive Card writes outside the configured Home chat", async () => {
+    const tool = createRingCentralArtifactTools(cfg).find(
+      (candidate) => candidate.name === "ringcentral_create_adaptive_card",
+    )!;
+
+    const result = await tool.execute("call-1", { chat_id: "team-1", text: "hello" } as any);
+
+    expect(result.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Home chat"),
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("creates an owner note directly in Home chat", async () => {
+    const tool = createRingCentralArtifactTools(cfg).find(
+      (candidate) => candidate.name === "ringcentral_create_note",
+    )!;
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ access_token: "owner-access", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-1", title: "Note" }));
+
+    const result = await tool.execute("call-1", { title: "Note" } as any);
+
+    expect(result.details).toMatchObject({ success: true, note_id: "note-1" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/home-dm/notes",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer owner-access" }),
+        body: JSON.stringify({ title: "Note" }),
+      }),
+    );
+  });
+
+  it("requires Home confirmation before owner note writes to another chat", async () => {
+    const tools = createRingCentralArtifactTools(cfg);
+    const createNote = tools.find((candidate) => candidate.name === "ringcentral_create_note")!;
+    const confirm = tools.find((candidate) => candidate.name === "ringcentral_confirm_artifact_action")!;
+
+    const pending = await createNote.execute("call-1", {
+      chat_id: "team-1",
+      title: "Team Note",
+    } as any);
+
+    expect(pending.details).toMatchObject({
+      success: false,
+      requiresConfirmation: true,
+      target_chat_id: "team-1",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    const confirmationId = (pending.details as any).confirmation_id;
+    const rejected = await confirm.execute("call-2", {
+      confirmation_id: confirmationId,
+      chat_id: "team-1",
+    } as any);
+    expect(rejected.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Home DM"),
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ access_token: "owner-access", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-2", title: "Team Note" }));
+
+    const confirmed = await confirm.execute("call-3", {
+      confirmation_id: confirmationId,
+      chat_id: "home-dm",
+    } as any);
+
+    expect(confirmed.details).toMatchObject({
+      success: true,
+      confirmed: true,
+      note_id: "note-2",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/team-1/notes",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const reuse = await confirm.execute("call-4", {
+      confirmation_id: confirmationId,
+      chat_id: "home-dm",
+    } as any);
+    expect(reuse.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Invalid or expired"),
+    });
+  });
+
+  it("requires homeChannel before owner-backed writes", async () => {
+    const noHomeCfg = {
+      channels: {
+        ringcentral: {
+          botToken: "bot-token",
+          ownerCredentials: cfg.channels.ringcentral.ownerCredentials,
+          server: "https://api.example.com",
+        },
+      },
+    };
+    const tool = createRingCentralArtifactTools(noHomeCfg).find(
+      (candidate) => candidate.name === "ringcentral_create_calendar_event",
+    )!;
+
+    const result = await tool.execute("call-1", {
+      chat_id: "team-1",
+      title: "Planning",
+      start_time: "2026-06-04T10:00:00Z",
+      end_time: "2026-06-04T11:00:00Z",
+    } as any);
+
+    expect(result.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("homeChannel"),
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -1,0 +1,713 @@
+import { randomBytes } from "node:crypto";
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
+import type { ChannelAgentTool } from "openclaw/plugin-sdk/channel-contract";
+import { Type } from "typebox";
+import { getRcConfig, hasOwnerCredentials, resolveAccount } from "./accounts.js";
+import { createBotClient, createOwnerClient, type RingCentralClient } from "./client.js";
+import { extractChatId } from "./targets.js";
+import type { CreateAdaptiveCardRequest, CreateEventRequest, CreateNoteRequest } from "./types.js";
+
+type ArtifactPendingAction =
+  | {
+      kind: "create-event";
+      chatId: string;
+      payload: CreateEventRequest;
+    }
+  | {
+      kind: "update-event";
+      chatId: string;
+      eventId: string;
+      payload: CreateEventRequest;
+    }
+  | {
+      kind: "delete-event";
+      chatId: string;
+      eventId: string;
+    }
+  | {
+      kind: "create-note";
+      chatId: string;
+      payload: CreateNoteRequest;
+      publish: boolean;
+    }
+  | {
+      kind: "update-note";
+      chatId: string;
+      noteId: string;
+      payload: Partial<CreateNoteRequest>;
+    }
+  | {
+      kind: "delete-note";
+      chatId: string;
+      noteId: string;
+    }
+  | {
+      kind: "publish-note";
+      chatId: string;
+      noteId: string;
+    };
+
+interface PendingEntry {
+  action: ArtifactPendingAction;
+  expiresAt: number;
+  summary: string;
+}
+
+const PENDING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+const pendingConfirmations = new Map<string, PendingEntry>();
+
+export const RINGCENTRAL_ARTIFACT_TOOL_NAMES = [
+  "ringcentral_confirm_artifact_action",
+  "ringcentral_create_adaptive_card",
+  "ringcentral_get_adaptive_card",
+  "ringcentral_update_adaptive_card",
+  "ringcentral_delete_adaptive_card",
+  "ringcentral_list_notes",
+  "ringcentral_create_note",
+  "ringcentral_get_note",
+  "ringcentral_update_note",
+  "ringcentral_delete_note",
+  "ringcentral_publish_note",
+  "ringcentral_list_calendar_events",
+  "ringcentral_create_calendar_event",
+  "ringcentral_get_calendar_event",
+  "ringcentral_update_calendar_event",
+  "ringcentral_delete_calendar_event",
+] as const;
+
+export const __testing = {
+  pendingConfirmations,
+};
+
+export function createRingCentralArtifactTools(cfg?: unknown): ChannelAgentTool[] {
+  return [
+    confirmArtifactActionTool(cfg),
+    createAdaptiveCardTool(cfg),
+    getAdaptiveCardTool(cfg),
+    updateAdaptiveCardTool(cfg),
+    deleteAdaptiveCardTool(cfg),
+    listNotesTool(cfg),
+    createNoteTool(cfg),
+    getNoteTool(cfg),
+    updateNoteTool(cfg),
+    deleteNoteTool(cfg),
+    publishNoteTool(cfg),
+    listEventsTool(cfg),
+    createEventTool(cfg),
+    getEventTool(cfg),
+    updateEventTool(cfg),
+    deleteEventTool(cfg),
+  ];
+}
+
+function confirmArtifactActionTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_confirm_artifact_action",
+    label: "Confirm RingCentral Artifact Action",
+    description: "Confirm a pending RingCentral owner-backed artifact write from the configured Home DM.",
+    parameters: Type.Object({
+      confirmation_id: Type.String(),
+      chat_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      return confirmArtifactAction({
+        cfg,
+        confirmationId: readString(params.confirmation_id),
+        chatId: readChatId(params.chat_id),
+      });
+    },
+  };
+}
+
+function createAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_create_adaptive_card",
+    label: "Create RingCentral Adaptive Card",
+    description: "Create an Adaptive Card in the configured RingCentral Home chat using the bot token.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      card: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      text: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      return runBotCardTool(cfg, params, async (client, chatId) => {
+        const card = await client.createAdaptiveCard(chatId, adaptiveCardPayload(params));
+        return okResult({ success: true, card_id: card.id, type: card.type });
+      });
+    },
+  };
+}
+
+function getAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_get_adaptive_card",
+    label: "Get RingCentral Adaptive Card",
+    description: "Read a RingCentral Adaptive Card by card ID using the bot token.",
+    parameters: Type.Object({
+      card_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const cardId = readString(params.card_id);
+      if (!cardId) return errorResult("card_id is required.");
+      const account = resolveArtifactAccount(cfg);
+      const client = createBotClient(account.server, account.botToken);
+      const card = await client.getAdaptiveCard(cardId);
+      return okResult({ success: true, card });
+    },
+  };
+}
+
+function updateAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_update_adaptive_card",
+    label: "Update RingCentral Adaptive Card",
+    description: "Replace an Adaptive Card from the configured RingCentral Home chat using the bot token.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      card_id: Type.String(),
+      card: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      text: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const cardId = readString(params.card_id);
+      if (!cardId) return errorResult("card_id is required.");
+      return runBotCardTool(cfg, params, async (client) => {
+        const card = await client.updateAdaptiveCard(cardId, adaptiveCardPayload(params));
+        return okResult({ success: true, card_id: card.id, type: card.type });
+      });
+    },
+  };
+}
+
+function deleteAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_delete_adaptive_card",
+    label: "Delete RingCentral Adaptive Card",
+    description: "Delete an Adaptive Card by card ID using the bot token.",
+    parameters: Type.Object({
+      card_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const cardId = readString(params.card_id);
+      if (!cardId) return errorResult("card_id is required.");
+      const account = resolveArtifactAccount(cfg);
+      const client = createBotClient(account.server, account.botToken);
+      await client.deleteAdaptiveCard(cardId);
+      return okResult({ success: true, deleted: true });
+    },
+  };
+}
+
+function listNotesTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_list_notes",
+    label: "List RingCentral Notes",
+    description: "List notes in the configured RingCentral Home chat using owner credentials.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      record_count: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      return runOwnerReadTool(cfg, params, async (client, chatId) => {
+        const result = await client.listNotes(chatId);
+        return okResult({
+          success: true,
+          notes: result.records,
+          fetched_count: result.records.length,
+        });
+      });
+    },
+  };
+}
+
+function createNoteTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_create_note",
+    label: "Create RingCentral Note",
+    description: "Create a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      title: Type.String(),
+      body: Type.Optional(Type.String()),
+      publish: Type.Optional(Type.Boolean()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const title = readString(params.title);
+      if (!title) return errorResult("title is required.");
+      const action: ArtifactPendingAction = {
+        kind: "create-note",
+        chatId: "",
+        payload: { title, body: readOptionalString(params.body) },
+        publish: Boolean(params.publish),
+      };
+      return runOwnerWriteTool(cfg, params, action, "create note");
+    },
+  };
+}
+
+function getNoteTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_get_note",
+    label: "Get RingCentral Note",
+    description: "Read a RingCentral note by note ID using owner credentials.",
+    parameters: Type.Object({
+      note_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const noteId = readString(params.note_id);
+      if (!noteId) return errorResult("note_id is required.");
+      const client = createOwnerArtifactClient(cfg);
+      const note = await client.getNote(noteId);
+      return okResult({ success: true, note });
+    },
+  };
+}
+
+function updateNoteTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_update_note",
+    label: "Update RingCentral Note",
+    description: "Update a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      note_id: Type.String(),
+      title: Type.Optional(Type.String()),
+      body: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const noteId = readString(params.note_id);
+      if (!noteId) return errorResult("note_id is required.");
+      const payload: Partial<CreateNoteRequest> = {};
+      if (params.title !== undefined) payload.title = String(params.title);
+      if (params.body !== undefined) payload.body = String(params.body);
+      if (!payload.title && !payload.body) return errorResult("title or body is required.");
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "update-note", chatId: "", noteId, payload },
+        `update note ${noteId}`,
+      );
+    },
+  };
+}
+
+function deleteNoteTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_delete_note",
+    label: "Delete RingCentral Note",
+    description: "Delete a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      note_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const noteId = readString(params.note_id);
+      if (!noteId) return errorResult("note_id is required.");
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "delete-note", chatId: "", noteId },
+        `delete note ${noteId}`,
+      );
+    },
+  };
+}
+
+function publishNoteTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_publish_note",
+    label: "Publish RingCentral Note",
+    description: "Publish a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      note_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const noteId = readString(params.note_id);
+      if (!noteId) return errorResult("note_id is required.");
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "publish-note", chatId: "", noteId },
+        `publish note ${noteId}`,
+      );
+    },
+  };
+}
+
+function listEventsTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_list_calendar_events",
+    label: "List RingCentral Calendar Events",
+    description: "List calendar events in the configured RingCentral Home chat using owner credentials.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      record_count: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      return runOwnerReadTool(cfg, params, async (client, chatId) => {
+        const result = await client.listEvents(chatId, clampCount(params.record_count, 50, 1, 100));
+        return okResult({
+          success: true,
+          events: result.records,
+          fetched_count: result.records.length,
+        });
+      });
+    },
+  };
+}
+
+function createEventTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_create_calendar_event",
+    label: "Create RingCentral Calendar Event",
+    description: "Create a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      title: Type.String(),
+      start_time: Type.String(),
+      end_time: Type.String(),
+      description: Type.Optional(Type.String()),
+      location: Type.Optional(Type.String()),
+      all_day: Type.Optional(Type.Boolean()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const payload = eventPayload(params);
+      if (!payload.title || !payload.startTime || !payload.endTime) {
+        return errorResult("title, start_time, and end_time are required.");
+      }
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "create-event", chatId: "", payload },
+        "create calendar event",
+      );
+    },
+  };
+}
+
+function getEventTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_get_calendar_event",
+    label: "Get RingCentral Calendar Event",
+    description: "Read a RingCentral calendar event by event ID using owner credentials.",
+    parameters: Type.Object({
+      event_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const eventId = readString(params.event_id);
+      if (!eventId) return errorResult("event_id is required.");
+      const client = createOwnerArtifactClient(cfg);
+      const event = await client.getEvent(eventId);
+      return okResult({ success: true, event });
+    },
+  };
+}
+
+function updateEventTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_update_calendar_event",
+    label: "Update RingCentral Calendar Event",
+    description: "Update a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      event_id: Type.String(),
+      title: Type.String(),
+      start_time: Type.String(),
+      end_time: Type.String(),
+      description: Type.Optional(Type.String()),
+      location: Type.Optional(Type.String()),
+      all_day: Type.Optional(Type.Boolean()),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const eventId = readString(params.event_id);
+      if (!eventId) return errorResult("event_id is required.");
+      const payload = eventPayload(params);
+      if (!payload.title || !payload.startTime || !payload.endTime) {
+        return errorResult("title, start_time, and end_time are required.");
+      }
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "update-event", chatId: "", eventId, payload },
+        `update calendar event ${eventId}`,
+      );
+    },
+  };
+}
+
+function deleteEventTool(cfg?: unknown): ChannelAgentTool {
+  return {
+    name: "ringcentral_delete_calendar_event",
+    label: "Delete RingCentral Calendar Event",
+    description: "Delete a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
+      event_id: Type.String(),
+    }),
+    execute: async (_toolCallId, rawParams) => {
+      const params = rawParams as Record<string, unknown>;
+      const eventId = readString(params.event_id);
+      if (!eventId) return errorResult("event_id is required.");
+      return runOwnerWriteTool(
+        cfg,
+        params,
+        { kind: "delete-event", chatId: "", eventId },
+        `delete calendar event ${eventId}`,
+      );
+    },
+  };
+}
+
+async function runBotCardTool(
+  cfg: unknown,
+  params: Record<string, unknown>,
+  fn: (client: RingCentralClient, chatId: string) => Promise<AgentToolResult<unknown>>,
+): Promise<AgentToolResult<unknown>> {
+  const account = resolveArtifactAccount(cfg);
+  const chatId = resolveToolChatId(params, account.homeChannel);
+  if (!chatId) {
+    return errorResult("chat_id is required unless RC_HOME_CHANNEL/homeChannel is configured.");
+  }
+  if (account.homeChannel && chatId !== account.homeChannel) {
+    return errorResult("RingCentral Adaptive Card tools can only target the configured Home chat.");
+  }
+  const client = createBotClient(account.server, account.botToken);
+  return fn(client, chatId);
+}
+
+async function runOwnerReadTool(
+  cfg: unknown,
+  params: Record<string, unknown>,
+  fn: (client: RingCentralClient, chatId: string) => Promise<AgentToolResult<unknown>>,
+): Promise<AgentToolResult<unknown>> {
+  const account = resolveArtifactAccount(cfg);
+  if (!hasOwnerCredentials(account)) {
+    return errorResult("RingCentral owner credentials are not configured.");
+  }
+  const chatId = resolveToolChatId(params, account.homeChannel);
+  if (!chatId) {
+    return errorResult("chat_id is required unless RC_HOME_CHANNEL/homeChannel is configured.");
+  }
+  if (account.homeChannel && chatId !== account.homeChannel) {
+    return errorResult("RingCentral owner artifact reads can only target the configured Home chat.");
+  }
+  return fn(createOwnerArtifactClient(cfg), chatId);
+}
+
+async function runOwnerWriteTool(
+  cfg: unknown,
+  params: Record<string, unknown>,
+  action: ArtifactPendingAction,
+  summary: string,
+): Promise<AgentToolResult<unknown>> {
+  const account = resolveArtifactAccount(cfg);
+  if (!hasOwnerCredentials(account)) {
+    return errorResult("RingCentral owner credentials are not configured.");
+  }
+  if (!account.homeChannel) {
+    return errorResult("RC_HOME_CHANNEL/homeChannel must be configured before owner-backed artifact writes.");
+  }
+  const chatId = resolveToolChatId(params, account.homeChannel);
+  if (!chatId) {
+    return errorResult("chat_id is required.");
+  }
+  const scopedAction = { ...action, chatId } as ArtifactPendingAction;
+  if (chatId !== account.homeChannel) {
+    const confirmationId = createPendingConfirmation(scopedAction, summary);
+    return okResult({
+      success: false,
+      requiresConfirmation: true,
+      confirmation_id: confirmationId,
+      summary,
+      target_chat_id: chatId,
+      instruction: "Call ringcentral_confirm_artifact_action from the configured Home DM to execute this write.",
+    });
+  }
+  return executePendingAction(createOwnerArtifactClient(cfg), scopedAction);
+}
+
+async function confirmArtifactAction(params: {
+  cfg?: unknown;
+  confirmationId?: string;
+  chatId?: string;
+}): Promise<AgentToolResult<unknown>> {
+  const account = resolveArtifactAccount(params.cfg);
+  if (!account.homeChannel) {
+    return errorResult("RC_HOME_CHANNEL/homeChannel must be configured before confirming artifact writes.");
+  }
+  if (!params.chatId || params.chatId !== account.homeChannel) {
+    return errorResult("RingCentral artifact confirmations must be sent from the configured Home DM.");
+  }
+  if (!params.confirmationId) {
+    return errorResult("confirmation_id is required.");
+  }
+  cleanExpiredPendingConfirmations();
+  const pending = pendingConfirmations.get(params.confirmationId);
+  if (!pending) {
+    return errorResult("Invalid or expired artifact confirmation.");
+  }
+  pendingConfirmations.delete(params.confirmationId);
+  const result = await executePendingAction(createOwnerArtifactClient(params.cfg), pending.action);
+  return {
+    ...result,
+    details: {
+      ...(result.details as Record<string, unknown>),
+      confirmed: true,
+      summary: pending.summary,
+    },
+  };
+}
+
+async function executePendingAction(
+  client: RingCentralClient,
+  action: ArtifactPendingAction,
+): Promise<AgentToolResult<unknown>> {
+  switch (action.kind) {
+    case "create-event": {
+      const event = await client.createEvent(action.chatId, action.payload);
+      return okResult({ success: true, event_id: event.id, event });
+    }
+    case "update-event": {
+      const event = await client.updateEvent(action.eventId, action.payload);
+      return okResult({ success: true, event_id: event.id, event });
+    }
+    case "delete-event":
+      await client.deleteEvent(action.eventId);
+      return okResult({ success: true, event_id: action.eventId, deleted: true });
+    case "create-note": {
+      const note = await client.createNote(action.chatId, action.payload);
+      let published = false;
+      if (action.publish) {
+        await client.publishNote(note.id);
+        published = true;
+      }
+      return okResult({ success: true, note_id: note.id, published, note });
+    }
+    case "update-note": {
+      const note = await client.updateNote(action.noteId, action.payload);
+      return okResult({ success: true, note_id: note.id, note });
+    }
+    case "delete-note":
+      await client.deleteNote(action.noteId);
+      return okResult({ success: true, note_id: action.noteId, deleted: true });
+    case "publish-note":
+      await client.publishNote(action.noteId);
+      return okResult({ success: true, note_id: action.noteId, published: true });
+  }
+}
+
+function createPendingConfirmation(action: ArtifactPendingAction, summary: string): string {
+  cleanExpiredPendingConfirmations();
+  const confirmationId = randomBytes(16).toString("hex");
+  pendingConfirmations.set(confirmationId, {
+    action,
+    summary,
+    expiresAt: Date.now() + PENDING_CONFIRMATION_TTL_MS,
+  });
+  return confirmationId;
+}
+
+function cleanExpiredPendingConfirmations(): void {
+  const now = Date.now();
+  for (const [id, pending] of pendingConfirmations) {
+    if (now >= pending.expiresAt) {
+      pendingConfirmations.delete(id);
+    }
+  }
+}
+
+function resolveArtifactAccount(cfg: unknown) {
+  return resolveAccount(getRcConfig(cfg ?? {}));
+}
+
+function createOwnerArtifactClient(cfg: unknown): RingCentralClient {
+  const account = resolveArtifactAccount(cfg);
+  if (!hasOwnerCredentials(account)) {
+    throw new Error("RingCentral owner credentials are not configured.");
+  }
+  return createOwnerClient(
+    account.server,
+    account.ownerCredentials!.clientId,
+    account.ownerCredentials!.clientSecret,
+    account.ownerCredentials!.jwt,
+  );
+}
+
+function resolveToolChatId(params: Record<string, unknown>, fallback?: string): string | undefined {
+  return readChatId(params.chat_id ?? params.chatId ?? params.target) ?? fallback;
+}
+
+function readChatId(value: unknown): string | undefined {
+  const raw = readString(value);
+  if (!raw) return undefined;
+  return extractChatId(raw) ?? raw;
+}
+
+function adaptiveCardPayload(params: Record<string, unknown>): CreateAdaptiveCardRequest {
+  if (isRecord(params.card)) {
+    return { ...params.card, type: "AdaptiveCard" } as CreateAdaptiveCardRequest;
+  }
+  const text = readString(params.text) ?? "RingCentral Adaptive Card";
+  return {
+    type: "AdaptiveCard",
+    version: "1.3",
+    body: [{ type: "TextBlock", text, wrap: true }],
+  };
+}
+
+function eventPayload(params: Record<string, unknown>): CreateEventRequest {
+  const payload: CreateEventRequest = {
+    title: readString(params.title) ?? "",
+    startTime: readString(params.start_time ?? params.startTime ?? params.start) ?? "",
+    endTime: readString(params.end_time ?? params.endTime ?? params.end) ?? "",
+  };
+  if (params.description !== undefined) payload.description = String(params.description);
+  if (params.location !== undefined) payload.location = String(params.location);
+  if (params.all_day !== undefined) payload.allDay = Boolean(params.all_day);
+  if (params.allDay !== undefined) payload.allDay = Boolean(params.allDay);
+  return payload;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return value === undefined || value === null ? undefined : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function clampCount(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = Number(value ?? fallback);
+  return Math.min(Math.max(Number.isFinite(parsed) ? Math.trunc(parsed) : fallback, min), max);
+}
+
+function okResult(details: Record<string, unknown>): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
+    details,
+  };
+}
+
+function errorResult(message: string): AgentToolResult<unknown> {
+  return okResult({ success: false, error: message });
+}

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -301,33 +301,39 @@ function updateNoteTool(cfg?: unknown): ChannelAgentTool {
 }
 
 function deleteNoteTool(cfg?: unknown): ChannelAgentTool {
-  return {
+  return noteIdWriteTool({
+    cfg,
     name: "ringcentral_delete_note",
     label: "Delete RingCentral Note",
     description: "Delete a RingCentral note. Non-Home chat writes require Home DM confirmation.",
-    parameters: Type.Object({
-      chat_id: Type.Optional(Type.String()),
-      note_id: Type.String(),
-    }),
-    execute: async (_toolCallId, rawParams) => {
-      const params = rawParams as Record<string, unknown>;
-      const noteId = readString(params.note_id);
-      if (!noteId) return errorResult("note_id is required.");
-      return runOwnerWriteTool(
-        cfg,
-        params,
-        { kind: "delete-note", chatId: "", noteId },
-        `delete note ${noteId}`,
-      );
-    },
-  };
+    kind: "delete-note",
+    summaryVerb: "delete",
+  });
 }
 
 function publishNoteTool(cfg?: unknown): ChannelAgentTool {
-  return {
+  return noteIdWriteTool({
+    cfg,
     name: "ringcentral_publish_note",
     label: "Publish RingCentral Note",
     description: "Publish a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    kind: "publish-note",
+    summaryVerb: "publish",
+  });
+}
+
+function noteIdWriteTool(options: {
+  cfg?: unknown;
+  name: string;
+  label: string;
+  description: string;
+  kind: "delete-note" | "publish-note";
+  summaryVerb: string;
+}): ChannelAgentTool {
+  return {
+    name: options.name,
+    label: options.label,
+    description: options.description,
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       note_id: Type.String(),
@@ -337,10 +343,10 @@ function publishNoteTool(cfg?: unknown): ChannelAgentTool {
       const noteId = readString(params.note_id);
       if (!noteId) return errorResult("note_id is required.");
       return runOwnerWriteTool(
-        cfg,
+        options.cfg,
         params,
-        { kind: "publish-note", chatId: "", noteId },
-        `publish note ${noteId}`,
+        { kind: options.kind, chatId: "", noteId },
+        `${options.summaryVerb} note ${noteId}`,
       );
     },
   };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -10,6 +10,7 @@ import type {
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { getRcConfig, hasOwnerCredentials, isAccountConfigured, resolveAccount } from "./accounts.js";
 import { ringCentralMessageActions } from "./actions-adapter.js";
+import { createRingCentralArtifactTools } from "./artifact-tools.js";
 import { createBotClient, createOwnerClient, type RingCentralClient } from "./client.js";
 import { ringCentralConfigSchema } from "./config-schema.js";
 import { createRingCentralHistoryTool } from "./history-tool.js";
@@ -337,7 +338,10 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
   },
 
   actions: ringCentralMessageActions,
-  agentTools: ({ cfg }) => [createRingCentralHistoryTool(cfg)],
+  agentTools: ({ cfg }) => [
+    createRingCentralHistoryTool(cfg),
+    ...createRingCentralArtifactTools(cfg),
+  ],
 };
 
 function createOwnerClientFromAccount(account: ResolvedAccount): RingCentralClient | undefined {


### PR DESCRIPTION
## Summary
- expose RingCentral artifact actions as real optional OpenClaw agent tools
- register artifact tools in channel runtime and plugin metadata
- keep message actions on bot client by default
- gate owner-backed Note/Event writes behind Home DM confirmation

## Tests
- pnpm typecheck
- pnpm test
- git diff --check