### PR TITLE
Add inbound RingCentral attachment handoff

### DIFF
--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -23,10 +23,10 @@ on:
         required: false
         default: "30000"
       file_upload:
-        description: "Run optional file/image upload attachment smoke"
+        description: "Run file/image upload attachment smoke"
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   ringcentral-live-smoke:
@@ -42,7 +42,7 @@ jobs:
       RC_E2E_RECORD_COUNT: ${{ inputs.record_count || '50' }}
       RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == true && 'true' || 'false' }}
       RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
-      RC_E2E_FILE_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.file_upload == true && 'true' || 'false' }}
+      RC_E2E_FILE_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.file_upload == false && 'false' || 'true' }}
       RC_E2E_SOURCE_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
       RC_E2E_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}

--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -22,6 +22,11 @@ on:
         description: "Timeout for bot WebSocket connect/receive checks"
         required: false
         default: "30000"
+      file_upload:
+        description: "Run optional file/image upload attachment smoke"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   ringcentral-live-smoke:
@@ -37,6 +42,7 @@ jobs:
       RC_E2E_RECORD_COUNT: ${{ inputs.record_count || '50' }}
       RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == true && 'true' || 'false' }}
       RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
+      RC_E2E_FILE_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.file_upload == true && 'true' || 'false' }}
       RC_E2E_SOURCE_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
       RC_E2E_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RingCentral Team Messaging channel plugin for OpenClaw.
 - Optional owner JWT credentials for owner-observed groups, history reads, and fallback sends
 - OpenClaw channel ingress policy for DM/group allowlists, pairing, mention gates, and ignored/allowed channels
 - Threaded replies with `off`, `first`, and `all` modes
+- Inbound file/image attachments are downloaded into OpenClaw managed media storage after admission
 - Optional processing placeholder while an agent run is active
 - Shared OpenClaw `message` actions for send/read/edit/delete/channel-info
 - Optional `ringcentral_get_recent_messages` agent tool
@@ -72,6 +73,9 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 | `RC_REPLY_TO_MODE` | `off`, `first`, or `all`; default `first` |
 | `RC_PROCESSING_EMOJI_ENABLED` | Enable processing placeholder, default `true` |
 | `RC_PROCESSING_EMOJI_EDIT_DELAY_SECONDS` | Delay before placeholder update |
+| `RC_ATTACHMENT_DOWNLOAD_ENABLED` | Download admitted inbound attachments, default `true` |
+| `RC_ATTACHMENT_MAX_COUNT` | Max attachments per inbound message, default `5` |
+| `RC_ATTACHMENT_MAX_BYTES` | Max bytes per downloaded attachment, default `5242880` |
 | `RC_HISTORY_MESSAGE_LIMIT` | Default history record count, max `1000` |
 | `RC_HOME_CHANNEL` | Default history/home chat ID |
 | `RC_HOME_CHANNEL_NAME` | Display name for the home chat |
@@ -88,6 +92,9 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 | `dm.allowFrom` | `[]` | Stable sender IDs allowed in DMs |
 | `replyToMode` | `first` | Threading behavior for replies |
 | `noThreadChannels` | `[]` | Chat IDs that force unthreaded sends |
+| `attachments.enabled` | `true` | Download admitted RingCentral file/image attachments |
+| `attachments.maxCount` | `5` | Max attachments to process per inbound message |
+| `attachments.maxBytes` | `5242880` | Max bytes per downloaded attachment |
 | `allowBots` | `false` | Allow bot-authored inbound messages |
 
 When owner credentials are configured and no explicit DM allowlist is provided, the effective default is owner-only unless `allowAllUsers` is enabled.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -103,6 +103,14 @@
     "noThreadChannels": { "label": "No-thread Channels", "advanced": true },
     "replyToMode": { "label": "Reply-to Mode", "advanced": true },
     "processingPlaceholder": { "label": "Processing Placeholder", "advanced": true },
+    "attachments": {
+      "label": "Inbound Attachments",
+      "help": "Download admitted RingCentral file/image attachments into OpenClaw inbound media storage.",
+      "advanced": true
+    },
+    "attachments.enabled": { "label": "Download Attachments", "advanced": true },
+    "attachments.maxCount": { "label": "Max Attachments Per Message", "advanced": true },
+    "attachments.maxBytes": { "label": "Max Attachment Bytes", "advanced": true },
     "historyMessageLimit": { "label": "History Message Limit", "advanced": true },
     "homeChannel": { "label": "Home Channel", "advanced": true },
     "homeChannelName": { "label": "Home Channel Name", "advanced": true },
@@ -193,6 +201,15 @@
           "initialText": { "type": "string" },
           "delayedText": { "type": "string" },
           "editDelaySeconds": { "type": "integer", "minimum": 0, "maximum": 60 }
+        }
+      },
+      "attachments": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "maxCount": { "type": "integer", "minimum": 0, "maximum": 20 },
+          "maxBytes": { "type": "integer", "minimum": 1, "maximum": 104857600 }
         }
       },
       "historyMessageLimit": { "type": "integer", "minimum": 1, "maximum": 1000 },

--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -23,6 +23,11 @@ describe("resolveAccount", () => {
     expect(account.replyToMode).toBe("first");
     expect(account.groupPolicy).toBe("disabled");
     expect(account.requireMention).toBe(true);
+    expect(account.attachments).toEqual({
+      enabled: true,
+      maxCount: 5,
+      maxBytes: 5 * 1024 * 1024,
+    });
     expect(account.ownerCredentials).toBeUndefined();
   });
 
@@ -69,6 +74,29 @@ describe("resolveAccount", () => {
   it("keeps bot-only DM default open", () => {
     expect(resolveAccount({ botToken: "bot" }).dmPolicy).toBe("open");
   });
+
+  it("resolves inbound attachment limits from config and RC_* env", () => {
+    process.env.RC_ATTACHMENT_DOWNLOAD_ENABLED = "false";
+    process.env.RC_ATTACHMENT_MAX_COUNT = "7";
+    process.env.RC_ATTACHMENT_MAX_BYTES = "12345";
+
+    expect(resolveAccount({ botToken: "bot" }).attachments).toEqual({
+      enabled: false,
+      maxCount: 7,
+      maxBytes: 12345,
+    });
+
+    expect(
+      resolveAccount({
+        botToken: "bot",
+        attachments: { enabled: true, maxCount: 2, maxBytes: 2048 },
+      }).attachments,
+    ).toEqual({
+      enabled: true,
+      maxCount: 2,
+      maxBytes: 2048,
+    });
+  });
 });
 
 describe("isAccountConfigured", () => {
@@ -91,6 +119,6 @@ describe("hasOwnerCredentials", () => {
         }),
       ),
     ).toBe(true);
-    expect(hasOwnerCredentials(resolveAccount({ botToken: "bot" }))).toBe(false);
+    expect(hasOwnerCredentials(resolveAccount({ botToken: "bot" }, {}))).toBe(false);
   });
 });

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -12,6 +12,10 @@ import type {
 export const DEFAULT_SERVER = "https://platform.ringcentral.com";
 export const DEFAULT_HISTORY_MESSAGE_LIMIT = 250;
 export const MAX_HISTORY_MESSAGE_LIMIT = 1000;
+export const DEFAULT_ATTACHMENT_MAX_COUNT = 5;
+export const DEFAULT_ATTACHMENT_MAX_BYTES = 5 * 1024 * 1024;
+export const MAX_ATTACHMENT_MAX_COUNT = 20;
+export const MAX_ATTACHMENT_MAX_BYTES = 100 * 1024 * 1024;
 
 const DEFAULT_PROCESSING_PLACEHOLDER: Required<ProcessingPlaceholderConfig> = {
   enabled: true,
@@ -122,6 +126,26 @@ function resolveProcessingPlaceholder(
   };
 }
 
+function resolveAttachmentDownloads(
+  cfg: RingCentralConfig,
+  env: NodeJS.ProcessEnv,
+): ResolvedAccount["attachments"] {
+  const attachments = cfg.attachments ?? {};
+  return {
+    enabled: readBoolean(attachments.enabled, true, "RC_ATTACHMENT_DOWNLOAD_ENABLED", env),
+    maxCount: clampInteger(
+      readNumber(attachments.maxCount, DEFAULT_ATTACHMENT_MAX_COUNT, "RC_ATTACHMENT_MAX_COUNT", env),
+      0,
+      MAX_ATTACHMENT_MAX_COUNT,
+    ),
+    maxBytes: clampInteger(
+      readNumber(attachments.maxBytes, DEFAULT_ATTACHMENT_MAX_BYTES, "RC_ATTACHMENT_MAX_BYTES", env),
+      1,
+      MAX_ATTACHMENT_MAX_BYTES,
+    ),
+  };
+}
+
 export function getRcConfig(cfg: unknown): RingCentralConfig {
   const channels = (cfg as Record<string, unknown> | undefined)?.channels as
     | Record<string, unknown>
@@ -174,6 +198,7 @@ export function resolveAccount(
     dmPolicy,
     textChunkLimit: cfg.textChunkLimit,
     processingPlaceholder: resolveProcessingPlaceholder(cfg, env),
+    attachments: resolveAttachmentDownloads(cfg, env),
     historyMessageLimit,
     homeChannel: cfg.homeChannel ?? readEnv("RC_HOME_CHANNEL", env),
     homeChannelName: cfg.homeChannelName ?? readEnv("RC_HOME_CHANNEL_NAME", env),

--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -365,7 +365,17 @@ describe("ringCentralMessageActions", () => {
   });
 
   it("returns no actions when unconfigured", () => {
-    expect(ringCentralMessageActions.describeMessageTool({ cfg: { channels: { ringcentral: {} } } as any })?.actions).toEqual([]);
+    const origEnv = { ...process.env };
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("RC_") || key.startsWith("RINGCENTRAL_")) {
+          delete process.env[key];
+        }
+      }
+      expect(ringCentralMessageActions.describeMessageTool({ cfg: { channels: { ringcentral: {} } } as any })?.actions).toEqual([]);
+    } finally {
+      process.env = origEnv;
+    }
   });
 
   it("extracts send target for shared send action", () => {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,0 +1,122 @@
+import { buildAgentMediaPayload, saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { mediaKindFromMime } from "openclaw/plugin-sdk/media-mime";
+import { isAuthzOrNotFoundError, type RingCentralClient } from "./client.js";
+import type { Attachment, ResolvedAccount } from "./types.js";
+
+type LogFn = (message: string) => void;
+
+export interface ResolveInboundAttachmentsOptions {
+  attachments: Attachment[] | undefined;
+  primaryClient: RingCentralClient;
+  fallbackClient?: RingCentralClient;
+  account: ResolvedAccount;
+  log?: LogFn;
+}
+
+interface NormalizedAttachment {
+  uri: string;
+  fileName: string;
+  contentType?: string;
+}
+
+export async function resolveInboundAttachmentsForAgent(
+  opts: ResolveInboundAttachmentsOptions,
+): Promise<Record<string, unknown>> {
+  const cfg = opts.account.attachments;
+  if (!cfg.enabled || cfg.maxCount <= 0 || !opts.attachments?.length) {
+    return {};
+  }
+
+  const mediaList: Array<{ path: string; contentType?: string | null }> = [];
+  for (const attachment of opts.attachments.slice(0, cfg.maxCount)) {
+    const normalized = normalizeAttachment(attachment);
+    if (!normalized) {
+      opts.log?.("[ringcentral] inbound attachment skipped: missing uri");
+      continue;
+    }
+    const downloaded = await downloadWithFallback({
+      attachment: normalized,
+      primaryClient: opts.primaryClient,
+      fallbackClient: opts.fallbackClient,
+      maxBytes: cfg.maxBytes,
+      log: opts.log,
+    });
+    if (!downloaded) {
+      continue;
+    }
+    try {
+      const saved = await saveMediaBuffer(
+        downloaded.buffer,
+        downloaded.contentType,
+        "inbound",
+        cfg.maxBytes,
+        downloaded.fileName,
+      );
+      mediaList.push({
+        path: saved.path,
+        contentType: saved.contentType ?? downloaded.contentType,
+      });
+      opts.log?.(
+        `[ringcentral] inbound attachment saved: kind=${mediaKindFromMime(saved.contentType ?? downloaded.contentType) ?? "document"} size=${downloaded.size}`,
+      );
+    } catch {
+      opts.log?.("[ringcentral] inbound attachment skipped: save failed");
+    }
+  }
+
+  return mediaList.length > 0 ? buildAgentMediaPayload(mediaList) : {};
+}
+
+function normalizeAttachment(attachment: Attachment): NormalizedAttachment | undefined {
+  const uri = (attachment.uri ?? attachment.contentUri ?? "").trim();
+  if (!uri) {
+    return undefined;
+  }
+  return {
+    uri,
+    fileName: normalizeFileName(attachment.fileName ?? attachment.name),
+    contentType: attachment.contentType?.trim() || undefined,
+  };
+}
+
+function normalizeFileName(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "attachment";
+  }
+  return trimmed.replace(/[\0\r\n]+/g, " ").trim() || "attachment";
+}
+
+async function downloadWithFallback(opts: {
+  attachment: NormalizedAttachment;
+  primaryClient: RingCentralClient;
+  fallbackClient?: RingCentralClient;
+  maxBytes: number;
+  log?: LogFn;
+}) {
+  try {
+    return await opts.primaryClient.downloadAttachment({
+      uri: opts.attachment.uri,
+      fileName: opts.attachment.fileName,
+      contentType: opts.attachment.contentType,
+      maxBytes: opts.maxBytes,
+    });
+  } catch (err) {
+    if (!opts.fallbackClient || !isAuthzOrNotFoundError(err)) {
+      opts.log?.("[ringcentral] inbound attachment skipped: download failed");
+      return undefined;
+    }
+  }
+
+  try {
+    return await opts.fallbackClient.downloadAttachment({
+      uri: opts.attachment.uri,
+      fileName: opts.attachment.fileName,
+      contentType: opts.attachment.contentType,
+      maxBytes: opts.maxBytes,
+    });
+  } catch {
+    opts.log?.("[ringcentral] inbound attachment skipped: fallback download failed");
+    return undefined;
+  }
+}

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -14,6 +14,20 @@ function jsonResponse(data: unknown, status = 200) {
   };
 }
 
+function binaryResponse(data: Uint8Array, status = 200, contentType = "application/octet-stream") {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    arrayBuffer: () =>
+      Promise.resolve(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)),
+    text: () => Promise.resolve(""),
+    headers: new Map([
+      ["content-type", contentType],
+      ["Content-Type", contentType],
+    ]),
+  };
+}
+
 beforeEach(() => {
   vi.useRealTimers();
   mockFetch.mockReset();
@@ -168,6 +182,61 @@ describe("RingCentralClient", () => {
           headers: expect.objectContaining({ "Content-Type": "image/png" }),
         }),
       );
+    });
+
+    it("downloadAttachment uses bearer auth and returns bounded media bytes", async () => {
+      mockFetch.mockResolvedValueOnce(binaryResponse(new Uint8Array([1, 2, 3]), 200, "image/png"));
+      const result = await client.downloadAttachment({
+        uri: "https://content.example.test/file",
+        fileName: "image.png",
+        maxBytes: 10,
+      });
+
+      expect(result).toMatchObject({
+        contentType: "image/png",
+        fileName: "image.png",
+        size: 3,
+      });
+      expect(Buffer.from(result.buffer)).toEqual(Buffer.from([1, 2, 3]));
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://content.example.test/file",
+        expect.objectContaining({
+          method: "GET",
+          headers: { Authorization: "Bearer tok" },
+        }),
+      );
+    });
+
+    it("downloadAttachment rejects oversized attachment bodies", async () => {
+      mockFetch.mockResolvedValueOnce(binaryResponse(new Uint8Array([1, 2, 3]), 200, "text/plain"));
+      await expect(
+        client.downloadAttachment({
+          uri: "https://content.example.test/file",
+          fileName: "note.txt",
+          maxBytes: 2,
+        }),
+      ).rejects.toThrow("RingCentral attachment too large");
+    });
+
+    it("downloadAttachment retries HTTP 429 with Retry-After", async () => {
+      vi.useFakeTimers();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          text: () => Promise.resolve("rate limited"),
+          headers: new Map([["Retry-After", "0.5"]]),
+        })
+        .mockResolvedValueOnce(binaryResponse(new Uint8Array([1]), 200, "text/plain"));
+
+      const promise = client.downloadAttachment({
+        uri: "https://content.example.test/file",
+        fileName: "note.txt",
+        maxBytes: 10,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(promise).resolves.toMatchObject({ size: 1 });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,7 @@
 // RingCentral REST API client. Supports bot static tokens and owner JWT credentials.
 
+import { detectMime, mimeTypeFromFilePath, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/media-runtime";
 import type {
   AdaptiveCard,
   Chat,
@@ -31,6 +33,20 @@ export interface ClientOptions {
 export interface SendPostOptions {
   parentPostId?: string | number | null;
   threadId?: string | number | null;
+}
+
+export interface DownloadAttachmentOptions {
+  uri: string;
+  fileName?: string;
+  contentType?: string;
+  maxBytes: number;
+}
+
+export interface DownloadedAttachment {
+  buffer: Buffer;
+  contentType: string;
+  fileName: string;
+  size: number;
 }
 
 type RequestBody = object | string | Uint8Array;
@@ -177,6 +193,51 @@ export class RingCentralClient {
     }
 
     throw new Error(`RingCentral API retry budget exhausted for ${method} ${path}`);
+  }
+
+  async downloadAttachment(opts: DownloadAttachmentOptions): Promise<DownloadedAttachment> {
+    const uri = opts.uri.trim();
+    if (!/^https?:\/\//i.test(uri)) {
+      throw new Error("RingCentral attachment URI must be HTTP(S)");
+    }
+    const token = await this.getToken();
+    const headers = {
+      Authorization: `Bearer ${token}`,
+    };
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      const resp = await fetch(uri, { method: "GET", headers });
+      this.lastStatus = resp.status;
+      if (resp.status === 429 && attempt < this.maxRetries) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, RingCentralClient.parseRetryAfter(resp.headers.get("Retry-After"))),
+        );
+        continue;
+      }
+      if (!resp.ok) {
+        throw new RingCentralApiError(resp.status, await resp.text(), "RingCentral attachment download failed");
+      }
+      const buffer = await readResponseWithLimit(resp, opts.maxBytes, {
+        chunkTimeoutMs: 30_000,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`RingCentral attachment too large: ${size} bytes (limit: ${maxBytes} bytes)`),
+      });
+      const fileName = normalizeAttachmentFileName(opts.fileName);
+      const contentType =
+        normalizeMimeType(opts.contentType) ??
+        normalizeMimeType(resp.headers.get("Content-Type")) ??
+        (await detectMime({ buffer, filePath: fileName })) ??
+        mimeTypeFromFilePath(fileName) ??
+        "application/octet-stream";
+      return {
+        buffer,
+        contentType,
+        fileName,
+        size: buffer.byteLength,
+      };
+    }
+
+    throw new Error("RingCentral attachment retry budget exhausted");
   }
 
   async createWebSocketToken(): Promise<WSTokenResponse> {
@@ -358,6 +419,14 @@ export class RingCentralClient {
   async deleteAdaptiveCard(cardId: string): Promise<void> {
     await this.request("DELETE", `/team-messaging/v1/adaptive-cards/${RingCentralClient.encodeId(cardId)}`);
   }
+}
+
+function normalizeAttachmentFileName(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "attachment";
+  }
+  return trimmed.replace(/[\0\r\n]+/g, " ").trim() || "attachment";
 }
 
 export function createBotClient(serverUrl: string, botToken: string): RingCentralClient {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -22,6 +22,12 @@ const processingPlaceholderSchema = z.object({
   editDelaySeconds: z.number().int().min(0).max(60).optional(),
 });
 
+const attachmentsSchema = z.object({
+  enabled: z.boolean().optional(),
+  maxCount: z.number().int().min(0).max(20).optional(),
+  maxBytes: z.number().int().min(1).max(100 * 1024 * 1024).optional(),
+});
+
 const dmSchema = z.object({
   policy: z.enum(["disabled", "allowlist", "pairing", "open"]).optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
@@ -54,6 +60,7 @@ export const ringCentralConfigSchema = z.object({
   noThreadChannels: stringListSchema,
   replyToMode: z.enum(["off", "first", "all"]).optional(),
   processingPlaceholder: processingPlaceholderSchema.optional(),
+  attachments: attachmentsSchema.optional(),
   historyMessageLimit: z.number().int().min(1).max(1000).optional(),
   homeChannel: z.string().optional(),
   homeChannelName: z.string().optional(),

--- a/src/history-tool.test.ts
+++ b/src/history-tool.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRingCentralHistoryTool } from "./history-tool.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+const origEnv = { ...process.env };
 
 function jsonResponse(data: unknown, status = 200) {
   return {
@@ -15,7 +16,16 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 beforeEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("RC_") || key.startsWith("RINGCENTRAL_")) {
+      delete process.env[key];
+    }
+  }
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  process.env = { ...origEnv };
 });
 
 describe("ringcentral_get_recent_messages", () => {

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAccount } from "./accounts.js";
 import { handleInboundPost, stripRcMentions } from "./inbound.js";
 import { ThreadParticipationTracker } from "./threading.js";
 import type { Post } from "./types.js";
+
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  saveMediaBuffer: saveMediaBufferMock,
+  buildAgentMediaPayload: (mediaList: Array<{ path: string; contentType?: string | null }>) => ({
+    MediaPath: mediaList[0]?.path,
+    MediaUrl: mediaList[0]?.path,
+    MediaType: mediaList[0]?.contentType ?? undefined,
+    MediaPaths: mediaList.map((media) => media.path),
+    MediaUrls: mediaList.map((media) => media.path),
+    MediaTypes: mediaList.map((media) => media.contentType ?? ""),
+  }),
+}));
 
 function makePost(overrides: Partial<Post> = {}): Post {
   return {
@@ -24,6 +38,12 @@ function makeClient(chatType = "Group", email = "user@example.com") {
     sendPost: vi.fn().mockResolvedValue({ id: "sent-1" }),
     updatePost: vi.fn(),
     deletePost: vi.fn(),
+    downloadAttachment: vi.fn().mockResolvedValue({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+      fileName: "image.png",
+      size: 5,
+    }),
   } as any;
 }
 
@@ -65,6 +85,16 @@ describe("stripRcMentions", () => {
 });
 
 describe("handleInboundPost", () => {
+  beforeEach(() => {
+    saveMediaBufferMock.mockReset();
+    saveMediaBufferMock.mockResolvedValue({
+      id: "image---saved.png",
+      path: "/tmp/openclaw/media/inbound/image---saved.png",
+      contentType: "image/png",
+      size: 5,
+    });
+  });
+
   it("dispatches allowed group messages through OpenClaw runtime", async () => {
     const runtime = makeRuntime();
     await handleInboundPost({
@@ -89,10 +119,15 @@ describe("handleInboundPost", () => {
 
   it("drops groups when groupPolicy is disabled", async () => {
     const runtime = makeRuntime();
+    const client = makeClient();
     await handleInboundPost({
-      post: makePost(),
+      post: makePost({
+        attachments: [
+          { id: "a1", type: "File", contentUri: "https://content.example.test/a.png" },
+        ],
+      }),
       cfg: {},
-      botClient: makeClient(),
+      botClient: client,
       account: resolveAccount({ botToken: "bot", groupPolicy: "disabled" }),
       botPersonId: "bot",
       channelRuntime: runtime,
@@ -100,6 +135,8 @@ describe("handleInboundPost", () => {
       log: vi.fn(),
     });
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(client.downloadAttachment).not.toHaveBeenCalled();
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
   });
 
   it("allows DM senders by email alias", async () => {
@@ -119,5 +156,55 @@ describe("handleInboundPost", () => {
       tracker: new ThreadParticipationTracker(),
     });
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("downloads admitted attachments into OpenClaw inbound media payload", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    await handleInboundPost({
+      post: makePost({
+        attachments: [
+          {
+            id: "a1",
+            type: "File",
+            contentUri: "https://content.example.test/a.png",
+            name: "image.png",
+            contentType: "image/png",
+          },
+        ],
+      }),
+      cfg: {},
+      botClient: client,
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        requireMention: false,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+    });
+
+    expect(client.downloadAttachment).toHaveBeenCalledWith({
+      uri: "https://content.example.test/a.png",
+      fileName: "image.png",
+      contentType: "image/png",
+      maxBytes: 5 * 1024 * 1024,
+    });
+    expect(saveMediaBufferMock).toHaveBeenCalledWith(
+      Buffer.from("image"),
+      "image/png",
+      "inbound",
+      5 * 1024 * 1024,
+      "image.png",
+    );
+    expect(runtime.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPath: "/tmp/openclaw/media/inbound/image---saved.png",
+        MediaType: "image/png",
+        MediaPaths: ["/tmp/openclaw/media/inbound/image---saved.png"],
+      }),
+    );
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -4,6 +4,7 @@ import type {
   ChannelIngressRouteDescriptor,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveInboundAttachmentsForAgent } from "./attachments.js";
 import type { RingCentralClient } from "./client.js";
 import { deleteMessage, sendMessage, sendTypingIndicator, updateMessage } from "./send.js";
 import { RINGCENTRAL_CHANNEL_ID } from "./shared.js";
@@ -148,6 +149,13 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   const bodyForAgent = stripRcMentions(text, inCtx.botPersonId, {
     preserveNonBotMentions: chatType === "direct" && !!account.ownerCredentials,
   });
+  const mediaPayload = await resolveInboundAttachmentsForAgent({
+    attachments: post.attachments,
+    primaryClient: botClient,
+    fallbackClient: ownerClient,
+    account,
+    log,
+  });
   const runtime = (inCtx.channelRuntime ?? {}) as ChannelRuntimeLike;
   const peer = {
     kind: chatType,
@@ -203,6 +211,7 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     OriginatingChannel: RINGCENTRAL_CHANNEL_ID,
     OriginatingTo: target,
     OwnerAllowFrom: allowFrom,
+    ...mediaPayload,
   });
 
   await dispatchReplyWithBufferedBlockDispatcher({

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -292,7 +292,7 @@ function buildBaseSummaryContext(): Record<string, SummaryDetail> {
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     record_count: readRecordCount(),
     ws_timeout_ms: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
-    file_upload: readBooleanEnv("RC_E2E_FILE_UPLOAD", false),
+    file_upload: readBooleanEnv("RC_E2E_FILE_UPLOAD", true),
   };
 }
 
@@ -651,7 +651,7 @@ function readLiveEnv(): LiveEnv {
     recordCount: readRecordCount(),
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     wsTimeoutMs: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
-    fileUpload: readBooleanEnv("RC_E2E_FILE_UPLOAD", false),
+    fileUpload: readBooleanEnv("RC_E2E_FILE_UPLOAD", true),
   };
   if (missing.length > 0) {
     throw new Error(`Missing RingCentral live smoke variables: ${missing.join(", ")}`);

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -6,6 +6,8 @@ import {
   createOwnerClient,
   type RingCentralClient,
 } from "../client.js";
+import { resolveAccount } from "../accounts.js";
+import { resolveInboundAttachmentsForAgent } from "../attachments.js";
 import { createRingCentralHistoryTool } from "../history-tool.js";
 import { RingCentralWebSocketMonitor } from "../monitor.js";
 import { sendMessage } from "../send.js";
@@ -66,6 +68,12 @@ liveDescribe("RingCentral live smoke", () => {
         assertClientCanReadHistory(botClient, env.chatId, env.recordCount),
       );
 
+      await runFileUploadScenario({
+        env,
+        botClient,
+        ownerClient,
+        createdOwnerPostIds,
+      });
       await runBotSendOwnerReadScenario({
         env,
         botClient,
@@ -157,6 +165,7 @@ interface LiveEnv {
   recordCount: number;
   cleanup: boolean;
   wsTimeoutMs: number;
+  fileUpload: boolean;
 }
 
 interface LiveClients {
@@ -270,6 +279,7 @@ function buildSummaryContext(env: LiveEnv): Record<string, SummaryDetail> {
     cleanup: env.cleanup,
     record_count: env.recordCount,
     ws_timeout_ms: env.wsTimeoutMs,
+    file_upload: env.fileUpload,
   };
 }
 
@@ -282,7 +292,106 @@ function buildBaseSummaryContext(): Record<string, SummaryDetail> {
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     record_count: readRecordCount(),
     ws_timeout_ms: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
+    file_upload: readBooleanEnv("RC_E2E_FILE_UPLOAD", false),
   };
+}
+
+async function runFileUploadScenario(
+  params: LiveClients & {
+    createdOwnerPostIds: string[];
+  },
+): Promise<void> {
+  if (!params.env.fileUpload) {
+    logSafe("file_upload", { enabled: false });
+    return;
+  }
+
+  const imageFileName = buildUniqueFileName("image", "png");
+  const documentFileName = buildUniqueFileName("document", "txt");
+  const wsWaiter = startBotWebSocketAttachmentWait({
+    botClient: params.botClient,
+    chatId: params.env.chatId,
+    expectedFileName: imageFileName,
+    timeoutMs: params.env.wsTimeoutMs,
+  });
+
+  try {
+    await liveStep("file_upload_ws_connect", () =>
+      withTimeout(wsWaiter.connected, params.env.wsTimeoutMs, "file_upload_ws_connect"),
+    );
+
+    const imageUpload = await liveStep("file_upload_image", () =>
+      params.ownerClient.uploadFile(
+        params.env.chatId,
+        imageFileName,
+        tinyPngBytes(),
+        "image/png",
+      ),
+    );
+    logSafe("file_upload_image", { uploaded: true });
+
+    const imageWsPost = await liveStep("file_upload_ws_receive", () =>
+      withTimeout(wsWaiter.received, params.env.wsTimeoutMs, "file_upload_ws_receive"),
+    );
+    assertLive(hasAttachment(imageWsPost, imageFileName), "file_upload_ws_receive");
+    logSafe("file_upload_ws_receive", { ws_received: true });
+
+    const imagePost = await liveStep("file_upload_image_bot_read", () =>
+      waitForAttachmentPost({
+        client: params.botClient,
+        chatId: params.env.chatId,
+        fileName: imageFileName,
+        uploaded: imageUpload,
+        recordCount: params.env.recordCount,
+      }),
+    );
+    assertLive(imagePost, "file_upload_image_bot_read");
+    params.createdOwnerPostIds.push(String(imagePost.id));
+    logSafe("file_upload_image_bot_read", { found: true });
+
+    await assertAttachmentHandoff({
+      stage: "file_upload_image_handoff",
+      env: params.env,
+      botClient: params.botClient,
+      ownerClient: params.ownerClient,
+      uploaded: imageUpload,
+      post: imagePost,
+    });
+
+    const documentUpload = await liveStep("file_upload_document", () =>
+      params.ownerClient.uploadFile(
+        params.env.chatId,
+        documentFileName,
+        Buffer.from("RingCentral live smoke document attachment\n", "utf8"),
+        "text/plain",
+      ),
+    );
+    logSafe("file_upload_document", { uploaded: true });
+
+    const documentPost = await liveStep("file_upload_document_bot_read", () =>
+      waitForAttachmentPost({
+        client: params.botClient,
+        chatId: params.env.chatId,
+        fileName: documentFileName,
+        uploaded: documentUpload,
+        recordCount: params.env.recordCount,
+      }),
+    );
+    assertLive(documentPost, "file_upload_document_bot_read");
+    params.createdOwnerPostIds.push(String(documentPost.id));
+    logSafe("file_upload_document_bot_read", { found: true });
+
+    await assertAttachmentHandoff({
+      stage: "file_upload_document_handoff",
+      env: params.env,
+      botClient: params.botClient,
+      ownerClient: params.ownerClient,
+      uploaded: documentUpload,
+      post: documentPost,
+    });
+  } finally {
+    await wsWaiter.stop();
+  }
 }
 
 async function runBotSendOwnerReadScenario(params: LiveClients): Promise<void> {
@@ -542,6 +651,7 @@ function readLiveEnv(): LiveEnv {
     recordCount: readRecordCount(),
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     wsTimeoutMs: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
+    fileUpload: readBooleanEnv("RC_E2E_FILE_UPLOAD", false),
   };
   if (missing.length > 0) {
     throw new Error(`Missing RingCentral live smoke variables: ${missing.join(", ")}`);
@@ -593,6 +703,19 @@ function buildUniqueText(label: string): string {
     .join("\n");
 }
 
+function buildUniqueFileName(label: string, extension: string): string {
+  const runId = process.env.GITHUB_RUN_ID ?? "local";
+  const attempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
+  return `openclaw-ringcentral-e2e-${label}-${runId}-${attempt}-${Date.now()}.${extension}`;
+}
+
+function tinyPngBytes(): Buffer {
+  return Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lS0N2wAAAABJRU5ErkJggg==",
+    "base64",
+  );
+}
+
 function buildCalendarEventPayload(label: string): CreateEventRequest {
   const marker = buildUniqueText(label).split("\n")[0] ?? `[openclaw-ringcentral-e2e:${label}:${Date.now()}]`;
   const start = new Date(Date.now() + 60 * 60 * 1000).toISOString();
@@ -637,6 +760,28 @@ async function waitForPost(
   return undefined;
 }
 
+async function waitForAttachmentPost(params: {
+  client: RingCentralClient;
+  chatId: string;
+  fileName: string;
+  uploaded: unknown;
+  recordCount: number;
+}): Promise<Post | undefined> {
+  const uploadedAsPost = normalizeUploadedPost(params.uploaded);
+  if (uploadedAsPost?.attachments?.length) {
+    return uploadedAsPost;
+  }
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const posts = await readRecentPosts(params.client, params.chatId, params.recordCount);
+    const found = posts.find((post) => hasAttachment(post, params.fileName));
+    if (found) {
+      return found;
+    }
+    await delay(1500);
+  }
+  return undefined;
+}
+
 async function findRecentPost(
   client: RingCentralClient,
   chatId: string,
@@ -645,6 +790,107 @@ async function findRecentPost(
 ): Promise<Post | undefined> {
   const posts = await readRecentPosts(client, chatId, recordCount);
   return posts.find((post) => post.text?.includes(expectedText));
+}
+
+function hasAttachment(post: Post, expectedFileName: string): boolean {
+  const attachments = post.attachments ?? [];
+  return attachments.some((attachment) => {
+    const names = [attachment.fileName, attachment.name].filter(Boolean).map(String);
+    if (names.some((name) => name === expectedFileName)) {
+      return true;
+    }
+    return names.length === 0 && Boolean(attachment.contentUri ?? attachment.uri ?? attachment.id);
+  });
+}
+
+function normalizeUploadedPost(uploaded: unknown): Post | undefined {
+  if (!uploaded || Array.isArray(uploaded) || typeof uploaded !== "object") {
+    return undefined;
+  }
+  const candidate = uploaded as Partial<Post>;
+  return candidate.id && candidate.groupId ? (candidate as Post) : undefined;
+}
+
+function extractUploadAttachments(uploaded: unknown): Post["attachments"] {
+  if (Array.isArray(uploaded)) {
+    return uploaded
+      .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === "object")
+      .map((entry) => ({
+        id: String(entry.id ?? ""),
+        type: String(entry.type ?? "File"),
+        name: typeof entry.name === "string" ? entry.name : undefined,
+        fileName: typeof entry.fileName === "string" ? entry.fileName : undefined,
+        contentUri: typeof entry.contentUri === "string" ? entry.contentUri : undefined,
+        uri: typeof entry.uri === "string" ? entry.uri : undefined,
+        contentType: typeof entry.contentType === "string" ? entry.contentType : undefined,
+        size: typeof entry.size === "number" ? entry.size : undefined,
+      }))
+      .filter((entry) => entry.id || entry.contentUri || entry.uri);
+  }
+  if (uploaded && typeof uploaded === "object") {
+    const maybePost = uploaded as Partial<Post>;
+    if (maybePost.attachments?.length) {
+      return maybePost.attachments;
+    }
+    const maybeAttachment = uploaded as {
+      id?: unknown;
+      name?: unknown;
+      fileName?: unknown;
+      contentUri?: unknown;
+      uri?: unknown;
+      contentType?: unknown;
+      size?: unknown;
+    };
+    if (typeof maybeAttachment.contentUri === "string" || typeof maybeAttachment.uri === "string") {
+      return [
+        {
+          id: String(maybeAttachment.id ?? ""),
+          type: "File",
+          name: typeof maybeAttachment.name === "string" ? maybeAttachment.name : undefined,
+          fileName: typeof maybeAttachment.fileName === "string" ? maybeAttachment.fileName : undefined,
+          contentUri:
+            typeof maybeAttachment.contentUri === "string" ? maybeAttachment.contentUri : undefined,
+          uri: typeof maybeAttachment.uri === "string" ? maybeAttachment.uri : undefined,
+          contentType:
+            typeof maybeAttachment.contentType === "string" ? maybeAttachment.contentType : undefined,
+          size: typeof maybeAttachment.size === "number" ? maybeAttachment.size : undefined,
+        },
+      ];
+    }
+  }
+  return undefined;
+}
+
+async function assertAttachmentHandoff(params: {
+  stage: string;
+  env: LiveEnv;
+  botClient: RingCentralClient;
+  ownerClient: RingCentralClient;
+  uploaded: unknown;
+  post: Post;
+}): Promise<void> {
+  const attachments = extractUploadAttachments(params.uploaded) ?? params.post.attachments;
+  assertLive(attachments?.length, params.stage);
+  const payload = await liveStep(params.stage, () =>
+    resolveInboundAttachmentsForAgent({
+      attachments,
+      primaryClient: params.botClient,
+      fallbackClient: params.ownerClient,
+      account: resolveAccount({
+        botToken: params.env.botToken,
+        ownerCredentials: {
+          clientId: params.env.ownerClientId,
+          clientSecret: params.env.ownerClientSecret,
+          jwt: params.env.ownerJwtToken,
+        },
+        attachments: { enabled: true, maxCount: 5, maxBytes: 5 * 1024 * 1024 },
+      }),
+      log: () => undefined,
+    }),
+  );
+  const mediaPaths = (payload as { MediaPaths?: unknown }).MediaPaths;
+  assertLive(Array.isArray(mediaPaths) && mediaPaths.length > 0, params.stage);
+  logSafe(params.stage, { media_payload: true });
 }
 
 function hasThreadMetadata(post: Post, rootPostId: string): boolean {
@@ -737,6 +983,62 @@ function startBotWebSocketWait(params: {
     },
     onDiagnostic: (event, details) => {
       logSafe("bot_ws_state", sanitizeDiagnostic(event, details));
+    },
+    log: () => undefined,
+  });
+  const monitorDone = monitor.start().catch((err) => {
+    if (!abortController.signal.aborted) {
+      connected.reject(err);
+      received.reject(err);
+    }
+  });
+  return {
+    connected: connected.promise,
+    received: received.promise,
+    stop: async () => {
+      abortController.abort();
+      await monitorDone.catch(() => undefined);
+    },
+  };
+}
+
+function startBotWebSocketAttachmentWait(params: {
+  botClient: RingCentralClient;
+  chatId: string;
+  expectedFileName: string;
+  timeoutMs: number;
+}): {
+  connected: Promise<void>;
+  received: Promise<Post>;
+  stop: () => Promise<void>;
+} {
+  const abortController = new AbortController();
+  const connected = createDeferred<void>();
+  const received = createDeferred<Post>();
+  connected.promise.catch(() => undefined);
+  received.promise.catch(() => undefined);
+  const monitor = new RingCentralWebSocketMonitor({
+    client: params.botClient,
+    filterOwnCreator: false,
+    abortSignal: abortController.signal,
+    ignoredTexts: [],
+    onConnected: () => {
+      logSafe("file_upload_ws_connect", { ws_connected: true });
+      connected.resolve();
+    },
+    onDisconnected: (err) => {
+      if (!abortController.signal.aborted) {
+        connected.reject(err ?? new Error("ws disconnected"));
+        received.reject(err ?? new Error("ws disconnected"));
+      }
+    },
+    onMessage: (post) => {
+      if (post.groupId === params.chatId && hasAttachment(post, params.expectedFileName)) {
+        received.resolve(post);
+      }
+    },
+    onDiagnostic: (event, details) => {
+      logSafe("file_upload_ws_state", sanitizeDiagnostic(event, details));
     },
     log: () => undefined,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,9 @@ export interface Post {
 export interface Attachment {
   id: string;
   type: string;
+  uri?: string;
   name?: string;
+  fileName?: string;
   contentUri?: string;
   contentType?: string;
   size?: number;
@@ -196,6 +198,12 @@ export interface ProcessingPlaceholderConfig {
   editDelaySeconds?: number;
 }
 
+export interface AttachmentDownloadConfig {
+  enabled?: boolean;
+  maxCount?: number;
+  maxBytes?: number;
+}
+
 export interface RingCentralConfig {
   enabled?: boolean;
   name?: string;
@@ -215,6 +223,7 @@ export interface RingCentralConfig {
   noThreadChannels?: string[];
   replyToMode?: RingCentralReplyToMode;
   processingPlaceholder?: ProcessingPlaceholderConfig;
+  attachments?: AttachmentDownloadConfig;
   historyMessageLimit?: number;
   homeChannel?: string;
   homeChannelName?: string;
@@ -264,6 +273,7 @@ export interface ResolvedAccount {
   dmPolicy: "disabled" | "allowlist" | "pairing" | "open";
   textChunkLimit?: number;
   processingPlaceholder: Required<ProcessingPlaceholderConfig>;
+  attachments: Required<AttachmentDownloadConfig>;
   historyMessageLimit: number;
   homeChannel?: string;
   homeChannelName?: string;


### PR DESCRIPTION
## Summary
- download RingCentral file/image attachments only after existing ingress admission passes
- save admitted attachments into OpenClaw inbound media storage and pass MediaPath/MediaTypes to the runtime
- add attachment config/env/schema/docs plus optional file-upload live smoke coverage

## Tests
- pnpm typecheck
- pnpm test
- git diff --check