### PR TITLE
Prepare 2026.6.6 GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate tag version
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const tag = process.env.GITHUB_REF_NAME || "";
+          if (!tag.startsWith("v")) {
+            console.error(`Release tag must start with "v": ${tag}`);
+            process.exit(1);
+          }
+          const version = tag.slice(1);
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          if (pkg.version !== version) {
+            console.error(`Tag ${tag} does not match package.json version ${pkg.version}`);
+            process.exit(1);
+          }
+          console.log(`Validated release ${tag}`);
+          NODE
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-ringcentral",
-  "version": "2026.6.3",
+  "version": "2026.6.6",
   "type": "module",
   "main": "index.ts",
   "description": "OpenClaw RingCentral Team Messaging channel plugin",


### PR DESCRIPTION
## Summary
- bump package version to 2026.6.6
- add tag-triggered GitHub Release workflow
- validate release tag against package.json before creating a release

## Tests
- GITHUB_REF_NAME=v2026.6.6 local version validation
- pnpm typecheck
- pnpm test
- git diff --check

## Release
After merge, push tag `v2026.6.6` from latest `main` to create the GitHub Release.