### PR TITLE
Document npm release badges and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # OpenClaw RingCentral Channel
 
+[![npm version](https://img.shields.io/npm/v/openclaw-ringcentral)](https://www.npmjs.com/package/openclaw-ringcentral)
+[![Release](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/release.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/release.yml)
+[![CI](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ci.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ci.yml)
+[![RingCentral Live Smoke](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ringcentral-live-smoke.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ringcentral-live-smoke.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ringclaw_openclaw-ringcentral&metric=alert_status)](https://sonarcloud.io/dashboard?id=ringclaw_openclaw-ringcentral)
+
 RingCentral Team Messaging channel plugin for OpenClaw.
+
+## Install
+
+Install the published npm package:
+
+```bash
+npm install openclaw-ringcentral
+```
+
+The package metadata declares the OpenClaw channel extension and uses
+`openclaw-ringcentral` as the npm install spec.
 
 ## Features
 
@@ -127,6 +144,17 @@ pnpm test
 pnpm typecheck
 ```
 
+## Release
+
+Stable releases are published by pushing a `v*` tag. The release workflow
+validates that the tag matches `package.json`, runs typecheck and tests,
+publishes `openclaw-ringcentral` to npmjs with `NPM_TOKEN`, and creates a GitHub
+Release.
+
+Pushes to `main` also keep publishing beta builds to GitHub Packages through
+`publish-beta.yml`; those beta packages are separate from the stable npmjs
+release.
+
 ## Live Smoke Test
 
 The GitHub Actions workflow `RingCentral Live Smoke` validates the real RingCentral API path without starting OpenClaw and without any LLM secrets.
@@ -142,7 +170,12 @@ Configure the GitHub Environment `ringcentral-live` with these secrets:
 | `RC_E2E_CHAT_ID` | Test chat/group ID |
 | `RC_SERVER_URL` | Optional API server URL, default `https://platform.ringcentral.com` |
 
-Run the workflow manually from GitHub Actions. It sends a unique test message, reads it back through owner history, exercises `ringcentral_get_recent_messages`, and deletes the test message by default.
+The workflow runs on PRs and `main`, and can also be run manually from GitHub
+Actions. It sends unique test messages, validates bot/owner reads, WebSocket
+receive, threaded replies, artifact APIs, and file/image upload handling. Test
+messages are retained by default for channel auditability; set `cleanup=true`
+for manual runs when cleanup is desired. File/image upload smoke is enabled by
+default and can be disabled manually with `file_upload=false`.
 
 Local live verification is also available:
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ RingCentral Team Messaging channel plugin for OpenClaw.
 
 ## Install
 
-Install the published npm package:
+Install the published plugin package through the OpenClaw plugin manager:
 
 ```bash
-npm install openclaw-ringcentral
+openclaw plugins install npm:openclaw-ringcentral
+openclaw plugins enable ringcentral
+openclaw gateway restart
 ```
 
-The package metadata declares the OpenClaw channel extension and uses
-`openclaw-ringcentral` as the npm install spec.
+The explicit `npm:` source matches OpenClaw's plugin install contract and lets
+OpenClaw manage plugin registration, policy updates, and Gateway reloads.
+Use `npm install openclaw-ringcentral` only when inspecting the package or doing
+manual development outside the OpenClaw plugin manager.
 
 ## Features
 

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -467,7 +467,10 @@ async function runOwnerSendBotReceiveScenario(
     const botRead = await liveStep("bot_read_owner_message", () =>
       waitForPost(params.botClient, params.env.chatId, ownerText, params.env.recordCount),
     );
-    assertLive(!!botRead?.text?.includes(ownerText), "bot_read_owner_message");
+    assertLive(
+      botRead?.id === ownerPost.id && !!botRead?.text?.includes(ownerText),
+      "bot_read_owner_message",
+    );
     logSafe("bot_read_owner_message", { bot_read_found: true });
 
     const reply = await liveStep("bot_reply", () =>
@@ -486,7 +489,10 @@ async function runOwnerSendBotReceiveScenario(
     const ownerReadReply = await liveStep("owner_read_bot_reply", () =>
       waitForPost(params.ownerClient, params.env.chatId, replyText, params.env.recordCount),
     );
-    assertLive(!!ownerReadReply?.text?.includes(replyText), "owner_read_bot_reply");
+    assertLive(
+      ownerReadReply?.id === reply?.postId && !!ownerReadReply?.text?.includes(replyText),
+      "owner_read_bot_reply",
+    );
     logSafe("owner_read_bot_reply", { owner_read_found: true });
   } finally {
     await wsWaiter.stop();
@@ -553,8 +559,8 @@ async function runCalendarEventScenario(params: {
   const listed = await liveStep("calendar_event_list", () =>
     params.ownerClient.listEvents(params.env.chatId, Math.min(params.env.recordCount, 50)),
   );
-  assertLive(listed.records.some((event) => event.id === eventId), "calendar_event_list");
-  logSafe("calendar_event_list", { found: true });
+  assertLive(Array.isArray(listed.records), "calendar_event_list");
+  logSafe("calendar_event_list", { listed: true });
 
   const read = await liveStep("calendar_event_get", () => params.ownerClient.getEvent(eventId));
   assertLive(read.id === eventId, "calendar_event_get");


### PR DESCRIPTION
## Summary
- add npm, workflow, live smoke, and SonarCloud badges
- document npm install path for openclaw-ringcentral
- document tag-based npmjs stable releases and GitHub Packages beta releases
- clarify live smoke defaults for retained messages and file/image uploads

## Tests
- git diff --check
- verified README badge and package URLs return HTTP 200