### PR TITLE
Add RingCentral inbound message debug logging

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -111,6 +111,11 @@
     "attachments.enabled": { "label": "Download Attachments", "advanced": true },
     "attachments.maxCount": { "label": "Max Attachments Per Message", "advanced": true },
     "attachments.maxBytes": { "label": "Max Attachment Bytes", "advanced": true },
+    "debugInboundMessages": {
+      "label": "Debug Inbound Message Text",
+      "help": "Log admitted RingCentral inbound message text for troubleshooting. Leave disabled in production.",
+      "advanced": true
+    },
     "historyMessageLimit": { "label": "History Message Limit", "advanced": true },
     "homeChannel": { "label": "Home Channel", "advanced": true },
     "homeChannelName": { "label": "Home Channel Name", "advanced": true },
@@ -212,6 +217,7 @@
           "maxBytes": { "type": "integer", "minimum": 1, "maximum": 104857600 }
         }
       },
+      "debugInboundMessages": { "type": "boolean" },
       "historyMessageLimit": { "type": "integer", "minimum": 1, "maximum": 1000 },
       "homeChannel": { "type": "string" },
       "homeChannelName": { "type": "string" },

--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -28,6 +28,7 @@ describe("resolveAccount", () => {
       maxCount: 5,
       maxBytes: 5 * 1024 * 1024,
     });
+    expect(account.debugInboundMessages).toBe(false);
     expect(account.ownerCredentials).toBeUndefined();
   });
 
@@ -36,11 +37,13 @@ describe("resolveAccount", () => {
     process.env.RC_SERVER_URL = "https://sandbox.example.com";
     process.env.RC_ALLOWED_USER_EMAILS = "Owner@Example.com, teammate@example.com";
     process.env.RC_REPLY_TO_MODE = "all";
+    process.env.RC_DEBUG_INBOUND_MESSAGES = "true";
     const account = resolveAccount({});
     expect(account.botToken).toBe("env-bot-token");
     expect(account.server).toBe("https://sandbox.example.com");
     expect(account.allowedUserEmails).toEqual(["owner@example.com", "teammate@example.com"]);
     expect(account.replyToMode).toBe("all");
+    expect(account.debugInboundMessages).toBe(true);
   });
 
   it("ignores deprecated RINGCENTRAL_* env", () => {
@@ -73,6 +76,10 @@ describe("resolveAccount", () => {
 
   it("keeps bot-only DM default open", () => {
     expect(resolveAccount({ botToken: "bot" }).dmPolicy).toBe("open");
+  });
+
+  it("resolves debug inbound message logging from config", () => {
+    expect(resolveAccount({ botToken: "bot", debugInboundMessages: true }).debugInboundMessages).toBe(true);
   });
 
   it("resolves inbound attachment limits from config and RC_* env", () => {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -199,6 +199,7 @@ export function resolveAccount(
     textChunkLimit: cfg.textChunkLimit,
     processingPlaceholder: resolveProcessingPlaceholder(cfg, env),
     attachments: resolveAttachmentDownloads(cfg, env),
+    debugInboundMessages: readBoolean(cfg.debugInboundMessages, false, "RC_DEBUG_INBOUND_MESSAGES", env),
     historyMessageLimit,
     homeChannel: cfg.homeChannel ?? readEnv("RC_HOME_CHANNEL", env),
     homeChannelName: cfg.homeChannelName ?? readEnv("RC_HOME_CHANNEL_NAME", env),

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -36,6 +36,7 @@ describe("ringCentralConfigSchema", () => {
         delayedText: "delay",
         editDelaySeconds: 3,
       },
+      debugInboundMessages: true,
       historyMessageLimit: 250,
       homeChannel: "g-home",
       homeChannelName: "Home",

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -61,6 +61,7 @@ export const ringCentralConfigSchema = z.object({
   replyToMode: z.enum(["off", "first", "all"]).optional(),
   processingPlaceholder: processingPlaceholderSchema.optional(),
   attachments: attachmentsSchema.optional(),
+  debugInboundMessages: z.boolean().optional(),
   historyMessageLimit: z.number().int().min(1).max(1000).optional(),
   homeChannel: z.string().optional(),
   homeChannelName: z.string().optional(),

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -70,6 +70,10 @@ function makeRuntime() {
   };
 }
 
+function loggedMessages(log: ReturnType<typeof vi.fn>): string[] {
+  return log.mock.calls.map(([message]) => String(message));
+}
+
 describe("stripRcMentions", () => {
   it("removes leading bot mentions and inline mentions", () => {
     expect(stripRcMentions("![:Person](bot) summarize ![:Person](u2)", "bot")).toBe("summarize");
@@ -117,6 +121,57 @@ describe("handleInboundPost", () => {
     );
   });
 
+  it("does not log inbound message text by default", async () => {
+    const runtime = makeRuntime();
+    const log = vi.fn();
+    await handleInboundPost({
+      post: makePost({ text: "private debug text" }),
+      cfg: {},
+      botClient: makeClient(),
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        requireMention: false,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log,
+    });
+
+    expect(loggedMessages(log).some((message) => message.includes("private debug text"))).toBe(false);
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("logs inbound message text when debug logging is enabled", async () => {
+    const runtime = makeRuntime();
+    const log = vi.fn();
+    await handleInboundPost({
+      post: makePost({ text: "debug me" }),
+      cfg: {},
+      botClient: makeClient(),
+      account: resolveAccount({
+        botToken: "bot",
+        debugInboundMessages: true,
+        groupPolicy: "open",
+        requireMention: false,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log,
+    });
+
+    const message = loggedMessages(log).find((entry) => entry.startsWith("[ringcentral] inbound message "));
+    expect(message).toContain('"chatId":"g1"');
+    expect(message).toContain('"creatorId":"u1"');
+    expect(message).toContain('"chatType":"group"');
+    expect(message).toContain('"textLength":8');
+    expect(message).toContain('"text":"debug me"');
+  });
+
   it("drops groups when groupPolicy is disabled", async () => {
     const runtime = makeRuntime();
     const client = makeClient();
@@ -137,6 +192,47 @@ describe("handleInboundPost", () => {
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(client.downloadAttachment).not.toHaveBeenCalled();
     expect(saveMediaBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("logs debug drop summary without attachment details", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const log = vi.fn();
+    await handleInboundPost({
+      post: makePost({
+        text: "drop me",
+        attachments: [
+          {
+            id: "a1",
+            type: "File",
+            contentUri: "https://content.example.test/a.png",
+            name: "secret.png",
+          },
+        ],
+      }),
+      cfg: {},
+      botClient: client,
+      account: resolveAccount({
+        botToken: "bot",
+        debugInboundMessages: true,
+        groupPolicy: "disabled",
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log,
+    });
+
+    const messages = loggedMessages(log);
+    expect(messages.some((message) => message.includes('"text":"drop me"'))).toBe(true);
+    const drop = messages.find((message) => message.startsWith("[ringcentral] inbound message dropped "));
+    expect(drop).toContain('"chatId":"g1"');
+    expect(drop).toContain('"textLength":7');
+    expect(drop).toContain("reasonCode");
+    expect(messages.join("\n")).not.toContain("https://content.example.test/a.png");
+    expect(messages.join("\n")).not.toContain("secret.png");
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(client.downloadAttachment).not.toHaveBeenCalled();
   });
 
   it("allows DM senders by email alias", async () => {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -85,6 +85,15 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     return;
   }
 
+  if (account.debugInboundMessages) {
+    logInboundMessageDebug(log, {
+      chatId,
+      chatType,
+      creatorId: senderId,
+      text,
+    });
+  }
+
   const mentionFacts = resolveMentionFacts({
     text,
     mentions: post.mentions,
@@ -143,6 +152,13 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
       reason: ingress.ingress.reasonCode,
       target: chatId,
     });
+    if (account.debugInboundMessages) {
+      logInboundDropDebug(log, {
+        chatId,
+        reasonCode: ingress.ingress.reasonCode,
+        textLength: text.length,
+      });
+    }
     return;
   }
 
@@ -468,6 +484,43 @@ function resolveMentionFacts(params: {
       explicitMentions.some((mention) => mention.id === params.botPersonId)
     : hasAnyMention;
   return { canDetectMention: true, wasMentioned, hasAnyMention };
+}
+
+function logInboundMessageDebug(
+  log: (message: string) => void,
+  details: {
+    chatId: string;
+    creatorId: string;
+    chatType: ChatType;
+    text: string;
+  },
+): void {
+  log(
+    `[ringcentral] inbound message ${JSON.stringify({
+      chatId: details.chatId,
+      creatorId: details.creatorId,
+      chatType: details.chatType,
+      textLength: details.text.length,
+      text: details.text,
+    })}`,
+  );
+}
+
+function logInboundDropDebug(
+  log: (message: string) => void,
+  details: {
+    chatId: string;
+    reasonCode: string;
+    textLength: number;
+  },
+): void {
+  log(
+    `[ringcentral] inbound message dropped ${JSON.stringify({
+      chatId: details.chatId,
+      reasonCode: details.reasonCode,
+      textLength: details.textLength,
+    })}`,
+  );
 }
 
 async function getChatSafe(client: RingCentralClient, chatId: string): Promise<Chat | null> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,7 @@ export interface RingCentralConfig {
   replyToMode?: RingCentralReplyToMode;
   processingPlaceholder?: ProcessingPlaceholderConfig;
   attachments?: AttachmentDownloadConfig;
+  debugInboundMessages?: boolean;
   historyMessageLimit?: number;
   homeChannel?: string;
   homeChannelName?: string;
@@ -274,6 +275,7 @@ export interface ResolvedAccount {
   textChunkLimit?: number;
   processingPlaceholder: Required<ProcessingPlaceholderConfig>;
   attachments: Required<AttachmentDownloadConfig>;
+  debugInboundMessages: boolean;
   historyMessageLimit: number;
   homeChannel?: string;
   homeChannelName?: string;


### PR DESCRIPTION
## Summary
- add explicit debugInboundMessages / RC_DEBUG_INBOUND_MESSAGES switch for inbound RingCentral message text logging
- keep logging disabled by default to avoid leaking user message text in production
- log drop reason summaries when debug logging is enabled without printing attachments, credentials, or post ids

## Test Plan
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack:check
- git diff --check