### PR TITLE
Fix RingCentral channel setup metadata and open group admission

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -190,7 +190,7 @@
     },
     "groupPolicy": {
       "label": "Group Policy",
-      "help": "How to handle group messages: disabled, allowlist, or open."
+      "help": "How to handle group messages: disabled, allowlist, or open. When open, plain group messages are accepted unless requireMention or groups.<chat-id>.requireMention is true."
     },
     "groups": {
       "label": "Allowed Groups",
@@ -215,7 +215,7 @@
     },
     "requireMention": {
       "label": "Require @Mention (Global)",
-      "help": "Default for all groups."
+      "help": "Default @mention requirement for groups. If unset, groupPolicy=open accepts plain group messages; set true to require @mentions by default."
     },
     "dm": {
       "label": "DM Settings",
@@ -503,6 +503,440 @@
           "adaptiveCards": {
             "type": "boolean"
           }
+        }
+      }
+    }
+  },
+  "channelConfigs": {
+    "ringcentral": {
+      "label": "RingCentral",
+      "description": "OpenClaw RingCentral Team Messaging channel plugin",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "botToken": {
+            "type": "string",
+            "description": "Bot static token (required)"
+          },
+          "ownerCredentials": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "clientId": {
+                "type": "string"
+              },
+              "clientSecret": {
+                "type": "string"
+              },
+              "jwt": {
+                "type": "string"
+              }
+            }
+          },
+          "credentials": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Deprecated config alias for ownerCredentials.",
+            "properties": {
+              "clientId": {
+                "type": "string"
+              },
+              "clientSecret": {
+                "type": "string"
+              },
+              "jwt": {
+                "type": "string"
+              }
+            }
+          },
+          "server": {
+            "type": "string"
+          },
+          "botExtensionId": {
+            "type": "string"
+          },
+          "selfOnly": {
+            "type": "boolean"
+          },
+          "allowedUserEmails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allowAllUsers": {
+            "type": "boolean"
+          },
+          "allowedChannels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ignoredChannels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "freeResponseChannels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "threadRequireMention": {
+            "type": "boolean"
+          },
+          "noThreadChannels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "replyToMode": {
+            "type": "string",
+            "enum": [
+              "off",
+              "first",
+              "all"
+            ]
+          },
+          "processingPlaceholder": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "initialText": {
+                "type": "string"
+              },
+              "delayedText": {
+                "type": "string"
+              },
+              "editDelaySeconds": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 60
+              }
+            }
+          },
+          "attachments": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "maxCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 20
+              },
+              "maxBytes": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 104857600
+              }
+            }
+          },
+          "debugInboundMessages": {
+            "type": "boolean"
+          },
+          "historyMessageLimit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          "homeChannel": {
+            "type": "string"
+          },
+          "homeChannelName": {
+            "type": "string"
+          },
+          "groupPolicy": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "allowlist",
+              "open"
+            ]
+          },
+          "groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "requireMention": {
+                  "type": "boolean"
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "requireMention": {
+            "type": "boolean"
+          },
+          "dm": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "policy": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "allowlist",
+                  "pairing",
+                  "open"
+                ]
+              },
+              "allowFrom": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "string",
+                    "number"
+                  ]
+                }
+              }
+            }
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "allowBots": {
+            "type": "boolean"
+          },
+          "workspace": {
+            "type": "string"
+          },
+          "actions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "messages": {
+                "type": "boolean"
+              },
+              "channelInfo": {
+                "type": "boolean"
+              },
+              "tasks": {
+                "type": "boolean"
+              },
+              "events": {
+                "type": "boolean"
+              },
+              "notes": {
+                "type": "boolean"
+              },
+              "adaptiveCards": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "uiHints": {
+        "enabled": {
+          "label": "Enable RingCentral"
+        },
+        "name": {
+          "label": "Account Name",
+          "placeholder": "My RingCentral Bot"
+        },
+        "botToken": {
+          "label": "Bot Token",
+          "placeholder": "Bot static token from RingCentral Developer Portal",
+          "sensitive": true
+        },
+        "ownerCredentials": {
+          "label": "Owner Credentials (optional)",
+          "advanced": true
+        },
+        "ownerCredentials.clientId": {
+          "label": "Owner Client ID",
+          "sensitive": true
+        },
+        "ownerCredentials.clientSecret": {
+          "label": "Owner Client Secret",
+          "sensitive": true
+        },
+        "ownerCredentials.jwt": {
+          "label": "Owner JWT Token",
+          "sensitive": true
+        },
+        "server": {
+          "label": "API Server",
+          "placeholder": "https://platform.ringcentral.com",
+          "advanced": true
+        },
+        "allowedUserEmails": {
+          "label": "Allowed User Emails",
+          "advanced": true
+        },
+        "allowAllUsers": {
+          "label": "Allow All Users",
+          "advanced": true
+        },
+        "allowedChannels": {
+          "label": "Allowed Channels",
+          "advanced": true
+        },
+        "ignoredChannels": {
+          "label": "Ignored Channels",
+          "advanced": true
+        },
+        "freeResponseChannels": {
+          "label": "Free-response Channels",
+          "advanced": true
+        },
+        "threadRequireMention": {
+          "label": "Require Mention in Threads",
+          "advanced": true
+        },
+        "noThreadChannels": {
+          "label": "No-thread Channels",
+          "advanced": true
+        },
+        "replyToMode": {
+          "label": "Reply-to Mode",
+          "advanced": true
+        },
+        "processingPlaceholder": {
+          "label": "Processing Placeholder",
+          "advanced": true
+        },
+        "attachments": {
+          "label": "Inbound Attachments",
+          "help": "Download admitted RingCentral file/image attachments into OpenClaw inbound media storage.",
+          "advanced": true
+        },
+        "attachments.enabled": {
+          "label": "Download Attachments",
+          "advanced": true
+        },
+        "attachments.maxCount": {
+          "label": "Max Attachments Per Message",
+          "advanced": true
+        },
+        "attachments.maxBytes": {
+          "label": "Max Attachment Bytes",
+          "advanced": true
+        },
+        "debugInboundMessages": {
+          "label": "Debug Inbound Message Text",
+          "help": "Log admitted RingCentral inbound message text for troubleshooting. Leave disabled in production.",
+          "advanced": true
+        },
+        "historyMessageLimit": {
+          "label": "History Message Limit",
+          "advanced": true
+        },
+        "homeChannel": {
+          "label": "Home Channel",
+          "advanced": true
+        },
+        "homeChannelName": {
+          "label": "Home Channel Name",
+          "advanced": true
+        },
+        "botExtensionId": {
+          "label": "Bot Extension ID",
+          "help": "Extension/person ID of the bot for @mention detection.",
+          "placeholder": "123456789"
+        },
+        "groupPolicy": {
+          "label": "Group Policy",
+          "help": "How to handle group messages: disabled, allowlist, or open. When open, plain group messages are accepted unless requireMention or groups.<chat-id>.requireMention is true."
+        },
+        "groups": {
+          "label": "Allowed Groups",
+          "help": "Group/Team configurations keyed by Chat ID."
+        },
+        "groups.*": {
+          "label": "Group Configuration"
+        },
+        "groups.*.enabled": {
+          "label": "Enabled"
+        },
+        "groups.*.requireMention": {
+          "label": "Require @Mention"
+        },
+        "groups.*.systemPrompt": {
+          "label": "System Prompt",
+          "placeholder": "Custom instructions for this group."
+        },
+        "groups.*.users": {
+          "label": "Allowed Users",
+          "placeholder": "User ID or email"
+        },
+        "requireMention": {
+          "label": "Require @Mention (Global)",
+          "help": "Default @mention requirement for groups. If unset, groupPolicy=open accepts plain group messages; set true to require @mentions by default."
+        },
+        "dm": {
+          "label": "DM Settings",
+          "advanced": true
+        },
+        "dm.policy": {
+          "label": "DM Policy"
+        },
+        "dm.allowFrom": {
+          "label": "DM Allowlist"
+        },
+        "textChunkLimit": {
+          "label": "Text Chunk Limit",
+          "placeholder": "4000",
+          "advanced": true
+        },
+        "allowBots": {
+          "label": "Allow Bot Senders",
+          "advanced": true
+        },
+        "actions": {
+          "label": "Actions"
+        },
+        "actions.messages": {
+          "label": "Messages"
+        },
+        "actions.channelInfo": {
+          "label": "Channel Info"
+        },
+        "actions.tasks": {
+          "label": "Tasks"
+        },
+        "actions.events": {
+          "label": "Events"
+        },
+        "actions.notes": {
+          "label": "Notes"
+        },
+        "actions.adaptiveCards": {
+          "label": "Adaptive Cards"
         }
       }
     }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,9 @@
   "id": "openclaw-ringcentral",
   "name": "RingCentral",
   "description": "OpenClaw RingCentral Team Messaging channel plugin",
-  "channels": ["ringcentral"],
+  "channels": [
+    "ringcentral"
+  ],
   "contracts": {
     "tools": [
       "ringcentral_get_recent_messages",
@@ -78,47 +80,109 @@
     }
   },
   "uiHints": {
-    "enabled": { "label": "Enable RingCentral" },
-    "name": { "label": "Account Name", "placeholder": "My RingCentral Bot" },
+    "enabled": {
+      "label": "Enable RingCentral"
+    },
+    "name": {
+      "label": "Account Name",
+      "placeholder": "My RingCentral Bot"
+    },
     "botToken": {
       "label": "Bot Token",
       "placeholder": "Bot static token from RingCentral Developer Portal",
       "sensitive": true
     },
-    "ownerCredentials": { "label": "Owner Credentials (optional)", "advanced": true },
-    "ownerCredentials.clientId": { "label": "Owner Client ID", "sensitive": true },
-    "ownerCredentials.clientSecret": { "label": "Owner Client Secret", "sensitive": true },
-    "ownerCredentials.jwt": { "label": "Owner JWT Token", "sensitive": true },
+    "ownerCredentials": {
+      "label": "Owner Credentials (optional)",
+      "advanced": true
+    },
+    "ownerCredentials.clientId": {
+      "label": "Owner Client ID",
+      "sensitive": true
+    },
+    "ownerCredentials.clientSecret": {
+      "label": "Owner Client Secret",
+      "sensitive": true
+    },
+    "ownerCredentials.jwt": {
+      "label": "Owner JWT Token",
+      "sensitive": true
+    },
     "server": {
       "label": "API Server",
       "placeholder": "https://platform.ringcentral.com",
       "advanced": true
     },
-    "allowedUserEmails": { "label": "Allowed User Emails", "advanced": true },
-    "allowAllUsers": { "label": "Allow All Users", "advanced": true },
-    "allowedChannels": { "label": "Allowed Channels", "advanced": true },
-    "ignoredChannels": { "label": "Ignored Channels", "advanced": true },
-    "freeResponseChannels": { "label": "Free-response Channels", "advanced": true },
-    "threadRequireMention": { "label": "Require Mention in Threads", "advanced": true },
-    "noThreadChannels": { "label": "No-thread Channels", "advanced": true },
-    "replyToMode": { "label": "Reply-to Mode", "advanced": true },
-    "processingPlaceholder": { "label": "Processing Placeholder", "advanced": true },
+    "allowedUserEmails": {
+      "label": "Allowed User Emails",
+      "advanced": true
+    },
+    "allowAllUsers": {
+      "label": "Allow All Users",
+      "advanced": true
+    },
+    "allowedChannels": {
+      "label": "Allowed Channels",
+      "advanced": true
+    },
+    "ignoredChannels": {
+      "label": "Ignored Channels",
+      "advanced": true
+    },
+    "freeResponseChannels": {
+      "label": "Free-response Channels",
+      "advanced": true
+    },
+    "threadRequireMention": {
+      "label": "Require Mention in Threads",
+      "advanced": true
+    },
+    "noThreadChannels": {
+      "label": "No-thread Channels",
+      "advanced": true
+    },
+    "replyToMode": {
+      "label": "Reply-to Mode",
+      "advanced": true
+    },
+    "processingPlaceholder": {
+      "label": "Processing Placeholder",
+      "advanced": true
+    },
     "attachments": {
       "label": "Inbound Attachments",
       "help": "Download admitted RingCentral file/image attachments into OpenClaw inbound media storage.",
       "advanced": true
     },
-    "attachments.enabled": { "label": "Download Attachments", "advanced": true },
-    "attachments.maxCount": { "label": "Max Attachments Per Message", "advanced": true },
-    "attachments.maxBytes": { "label": "Max Attachment Bytes", "advanced": true },
+    "attachments.enabled": {
+      "label": "Download Attachments",
+      "advanced": true
+    },
+    "attachments.maxCount": {
+      "label": "Max Attachments Per Message",
+      "advanced": true
+    },
+    "attachments.maxBytes": {
+      "label": "Max Attachment Bytes",
+      "advanced": true
+    },
     "debugInboundMessages": {
       "label": "Debug Inbound Message Text",
       "help": "Log admitted RingCentral inbound message text for troubleshooting. Leave disabled in production.",
       "advanced": true
     },
-    "historyMessageLimit": { "label": "History Message Limit", "advanced": true },
-    "homeChannel": { "label": "Home Channel", "advanced": true },
-    "homeChannelName": { "label": "Home Channel Name", "advanced": true },
+    "historyMessageLimit": {
+      "label": "History Message Limit",
+      "advanced": true
+    },
+    "homeChannel": {
+      "label": "Home Channel",
+      "advanced": true
+    },
+    "homeChannelName": {
+      "label": "Home Channel Name",
+      "advanced": true
+    },
     "botExtensionId": {
       "label": "Bot Extension ID",
       "help": "Extension/person ID of the bot for @mention detection.",
@@ -132,49 +196,95 @@
       "label": "Allowed Groups",
       "help": "Group/Team configurations keyed by Chat ID."
     },
-    "groups.*": { "label": "Group Configuration" },
-    "groups.*.enabled": { "label": "Enabled" },
-    "groups.*.requireMention": { "label": "Require @Mention" },
+    "groups.*": {
+      "label": "Group Configuration"
+    },
+    "groups.*.enabled": {
+      "label": "Enabled"
+    },
+    "groups.*.requireMention": {
+      "label": "Require @Mention"
+    },
     "groups.*.systemPrompt": {
       "label": "System Prompt",
       "placeholder": "Custom instructions for this group."
     },
-    "groups.*.users": { "label": "Allowed Users", "placeholder": "User ID or email" },
+    "groups.*.users": {
+      "label": "Allowed Users",
+      "placeholder": "User ID or email"
+    },
     "requireMention": {
       "label": "Require @Mention (Global)",
       "help": "Default for all groups."
     },
-    "dm": { "label": "DM Settings", "advanced": true },
-    "dm.policy": { "label": "DM Policy" },
-    "dm.allowFrom": { "label": "DM Allowlist" },
+    "dm": {
+      "label": "DM Settings",
+      "advanced": true
+    },
+    "dm.policy": {
+      "label": "DM Policy"
+    },
+    "dm.allowFrom": {
+      "label": "DM Allowlist"
+    },
     "textChunkLimit": {
       "label": "Text Chunk Limit",
       "placeholder": "4000",
       "advanced": true
     },
-    "allowBots": { "label": "Allow Bot Senders", "advanced": true },
-    "actions": { "label": "Actions" },
-    "actions.messages": { "label": "Messages" },
-    "actions.channelInfo": { "label": "Channel Info" },
-    "actions.tasks": { "label": "Tasks" },
-    "actions.events": { "label": "Events" },
-    "actions.notes": { "label": "Notes" },
-    "actions.adaptiveCards": { "label": "Adaptive Cards" }
+    "allowBots": {
+      "label": "Allow Bot Senders",
+      "advanced": true
+    },
+    "actions": {
+      "label": "Actions"
+    },
+    "actions.messages": {
+      "label": "Messages"
+    },
+    "actions.channelInfo": {
+      "label": "Channel Info"
+    },
+    "actions.tasks": {
+      "label": "Tasks"
+    },
+    "actions.events": {
+      "label": "Events"
+    },
+    "actions.notes": {
+      "label": "Notes"
+    },
+    "actions.adaptiveCards": {
+      "label": "Adaptive Cards"
+    }
   },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean" },
-      "name": { "type": "string" },
-      "botToken": { "type": "string", "description": "Bot static token (required)" },
+      "enabled": {
+        "type": "boolean"
+      },
+      "name": {
+        "type": "string"
+      },
+      "botToken": {
+        "type": "string",
+        "description": "Bot static token (required)"
+      },
       "ownerCredentials": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "clientId": { "type": "string" },
-          "clientSecret": { "type": "string" },
-          "jwt": { "type": "string" }
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          },
+          "jwt": {
+            "type": "string"
+          }
         }
       },
       "credentials": {
@@ -182,81 +292,217 @@
         "additionalProperties": false,
         "description": "Deprecated config alias for ownerCredentials.",
         "properties": {
-          "clientId": { "type": "string" },
-          "clientSecret": { "type": "string" },
-          "jwt": { "type": "string" }
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          },
+          "jwt": {
+            "type": "string"
+          }
         }
       },
-      "server": { "type": "string" },
-      "botExtensionId": { "type": "string" },
-      "selfOnly": { "type": "boolean" },
-      "allowedUserEmails": { "type": "array", "items": { "type": "string" } },
-      "allowAllUsers": { "type": "boolean" },
-      "allowedChannels": { "type": "array", "items": { "type": "string" } },
-      "ignoredChannels": { "type": "array", "items": { "type": "string" } },
-      "freeResponseChannels": { "type": "array", "items": { "type": "string" } },
-      "threadRequireMention": { "type": "boolean" },
-      "noThreadChannels": { "type": "array", "items": { "type": "string" } },
-      "replyToMode": { "type": "string", "enum": ["off", "first", "all"] },
+      "server": {
+        "type": "string"
+      },
+      "botExtensionId": {
+        "type": "string"
+      },
+      "selfOnly": {
+        "type": "boolean"
+      },
+      "allowedUserEmails": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "allowAllUsers": {
+        "type": "boolean"
+      },
+      "allowedChannels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ignoredChannels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "freeResponseChannels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "threadRequireMention": {
+        "type": "boolean"
+      },
+      "noThreadChannels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "replyToMode": {
+        "type": "string",
+        "enum": [
+          "off",
+          "first",
+          "all"
+        ]
+      },
       "processingPlaceholder": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" },
-          "initialText": { "type": "string" },
-          "delayedText": { "type": "string" },
-          "editDelaySeconds": { "type": "integer", "minimum": 0, "maximum": 60 }
+          "enabled": {
+            "type": "boolean"
+          },
+          "initialText": {
+            "type": "string"
+          },
+          "delayedText": {
+            "type": "string"
+          },
+          "editDelaySeconds": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 60
+          }
         }
       },
       "attachments": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" },
-          "maxCount": { "type": "integer", "minimum": 0, "maximum": 20 },
-          "maxBytes": { "type": "integer", "minimum": 1, "maximum": 104857600 }
+          "enabled": {
+            "type": "boolean"
+          },
+          "maxCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 20
+          },
+          "maxBytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 104857600
+          }
         }
       },
-      "debugInboundMessages": { "type": "boolean" },
-      "historyMessageLimit": { "type": "integer", "minimum": 1, "maximum": 1000 },
-      "homeChannel": { "type": "string" },
-      "homeChannelName": { "type": "string" },
-      "groupPolicy": { "type": "string", "enum": ["disabled", "allowlist", "open"] },
+      "debugInboundMessages": {
+        "type": "boolean"
+      },
+      "historyMessageLimit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 1000
+      },
+      "homeChannel": {
+        "type": "string"
+      },
+      "homeChannelName": {
+        "type": "string"
+      },
+      "groupPolicy": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "allowlist",
+          "open"
+        ]
+      },
       "groups": {
         "type": "object",
         "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "enabled": { "type": "boolean" },
-            "requireMention": { "type": "boolean" },
-            "systemPrompt": { "type": "string" },
-            "users": { "type": "array", "items": { "type": ["string", "number"] } }
+            "enabled": {
+              "type": "boolean"
+            },
+            "requireMention": {
+              "type": "boolean"
+            },
+            "systemPrompt": {
+              "type": "string"
+            },
+            "users": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "number"
+                ]
+              }
+            }
           }
         }
       },
-      "requireMention": { "type": "boolean" },
+      "requireMention": {
+        "type": "boolean"
+      },
       "dm": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "policy": { "type": "string", "enum": ["disabled", "allowlist", "pairing", "open"] },
-          "allowFrom": { "type": "array", "items": { "type": ["string", "number"] } }
+          "policy": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "allowlist",
+              "pairing",
+              "open"
+            ]
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "type": [
+                "string",
+                "number"
+              ]
+            }
+          }
         }
       },
-      "textChunkLimit": { "type": "integer", "minimum": 1 },
-      "allowBots": { "type": "boolean" },
-      "workspace": { "type": "string" },
+      "textChunkLimit": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "allowBots": {
+        "type": "boolean"
+      },
+      "workspace": {
+        "type": "string"
+      },
       "actions": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "messages": { "type": "boolean" },
-          "channelInfo": { "type": "boolean" },
-          "tasks": { "type": "boolean" },
-          "events": { "type": "boolean" },
-          "notes": { "type": "boolean" },
-          "adaptiveCards": { "type": "boolean" }
+          "messages": {
+            "type": "boolean"
+          },
+          "channelInfo": {
+            "type": "boolean"
+          },
+          "tasks": {
+            "type": "boolean"
+          },
+          "events": {
+            "type": "boolean"
+          },
+          "notes": {
+            "type": "boolean"
+          },
+          "adaptiveCards": {
+            "type": "boolean"
+          }
         }
       }
     }

--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -23,6 +23,7 @@ describe("resolveAccount", () => {
     expect(account.replyToMode).toBe("first");
     expect(account.groupPolicy).toBe("disabled");
     expect(account.requireMention).toBe(true);
+    expect(account.requireMentionExplicit).toBe(false);
     expect(account.attachments).toEqual({
       enabled: true,
       maxCount: 5,
@@ -37,12 +38,15 @@ describe("resolveAccount", () => {
     process.env.RC_SERVER_URL = "https://sandbox.example.com";
     process.env.RC_ALLOWED_USER_EMAILS = "Owner@Example.com, teammate@example.com";
     process.env.RC_REPLY_TO_MODE = "all";
+    process.env.RC_REQUIRE_MENTION = "false";
     process.env.RC_DEBUG_INBOUND_MESSAGES = "true";
     const account = resolveAccount({});
     expect(account.botToken).toBe("env-bot-token");
     expect(account.server).toBe("https://sandbox.example.com");
     expect(account.allowedUserEmails).toEqual(["owner@example.com", "teammate@example.com"]);
     expect(account.replyToMode).toBe("all");
+    expect(account.requireMention).toBe(false);
+    expect(account.requireMentionExplicit).toBe(true);
     expect(account.debugInboundMessages).toBe(true);
   });
 
@@ -80,6 +84,12 @@ describe("resolveAccount", () => {
 
   it("resolves debug inbound message logging from config", () => {
     expect(resolveAccount({ botToken: "bot", debugInboundMessages: true }).debugInboundMessages).toBe(true);
+  });
+
+  it("tracks explicit requireMention config", () => {
+    const account = resolveAccount({ botToken: "bot", requireMention: false });
+    expect(account.requireMention).toBe(false);
+    expect(account.requireMentionExplicit).toBe(true);
   });
 
   it("resolves inbound attachment limits from config and RC_* env", () => {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -179,6 +179,8 @@ export function resolveAccount(
     1,
     MAX_HISTORY_MESSAGE_LIMIT,
   );
+  const requireMentionEnv = readEnv("RC_REQUIRE_MENTION", env);
+  const requireMention = readBoolean(cfg.requireMention, true, "RC_REQUIRE_MENTION", env);
 
   return {
     botToken,
@@ -192,7 +194,8 @@ export function resolveAccount(
     freeResponseChannels: readDelimitedEntries(cfg.freeResponseChannels, "RC_FREE_RESPONSE_CHANNELS", env),
     noThreadChannels: readDelimitedEntries(cfg.noThreadChannels, "RC_NO_THREAD_CHANNELS", env),
     replyToMode: resolveReplyToMode(cfg.replyToMode, env),
-    requireMention: readBoolean(cfg.requireMention, true, "RC_REQUIRE_MENTION", env),
+    requireMention,
+    requireMentionExplicit: cfg.requireMention !== undefined || requireMentionEnv !== undefined,
     threadRequireMention: readBoolean(cfg.threadRequireMention, true, "RC_THREAD_REQUIRE_MENTION", env),
     groupPolicy: cfg.groupPolicy ?? "disabled",
     dmPolicy,

--- a/src/artifact-tools.test.ts
+++ b/src/artifact-tools.test.ts
@@ -45,6 +45,11 @@ describe("RingCentral artifact tools", () => {
     expect(tools).toEqual([...RINGCENTRAL_ARTIFACT_TOOL_NAMES]);
 
     const manifest = JSON.parse(readFileSync("openclaw.plugin.json", "utf8"));
+    expect(manifest.channelConfigs?.ringcentral).toMatchObject({
+      label: "RingCentral",
+      schema: manifest.configSchema,
+      uiHints: manifest.uiHints,
+    });
     for (const toolName of RINGCENTRAL_ARTIFACT_TOOL_NAMES) {
       expect(manifest.contracts.tools).toContain(toolName);
       expect(manifest.toolMetadata[toolName]).toEqual({ optional: true });

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -121,6 +121,52 @@ describe("handleInboundPost", () => {
     );
   });
 
+  it("does not require mentions by default when groupPolicy is open", async () => {
+    const runtime = makeRuntime();
+    await handleInboundPost({
+      post: makePost({ text: "plain group message" }),
+      cfg: {},
+      botClient: makeClient(),
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+    });
+
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("honors explicit requireMention when groupPolicy is open", async () => {
+    const runtime = makeRuntime();
+    const log = vi.fn();
+    await handleInboundPost({
+      post: makePost({ text: "plain group message" }),
+      cfg: {},
+      botClient: makeClient(),
+      account: resolveAccount({
+        botToken: "bot",
+        debugInboundMessages: true,
+        groupPolicy: "open",
+        requireMention: true,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log,
+    });
+
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    const drop = loggedMessages(log).find((message) => message.startsWith("[ringcentral] inbound message dropped "));
+    expect(drop).toContain('"reasonCode":"activation_skipped"');
+    expect(drop).toContain('"groupPolicy":"open"');
+    expect(drop).toContain('"requireMention":true');
+  });
+
   it("does not log inbound message text by default", async () => {
     const runtime = makeRuntime();
     const log = vi.fn();
@@ -192,6 +238,50 @@ describe("handleInboundPost", () => {
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(client.downloadAttachment).not.toHaveBeenCalled();
     expect(saveMediaBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("logs a non-debug drop warning once per chat without message text", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const log = vi.fn();
+    const post = makePost({
+      groupId: "warn-chat",
+      text: "private skipped text",
+      attachments: [
+        {
+          id: "a1",
+          type: "File",
+          contentUri: "https://content.example.test/private.png",
+          name: "private.png",
+        },
+      ],
+    });
+
+    for (let i = 0; i < 2; i += 1) {
+      await handleInboundPost({
+        post,
+        cfg: {},
+        botClient: client,
+        account: resolveAccount({ botToken: "bot", groupPolicy: "disabled" }),
+        botPersonId: "bot",
+        channelRuntime: runtime,
+        tracker: new ThreadParticipationTracker(),
+        log,
+      });
+    }
+
+    const messages = loggedMessages(log);
+    const warnings = messages.filter((message) => message.startsWith("[ringcentral] WARN inbound message dropped "));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"chatId":"warn-chat"');
+    expect(warnings[0]).toContain('"groupPolicy":"disabled"');
+    expect(warnings[0]).toContain('"requireMention":true');
+    expect(warnings[0]).toContain('"debugHint"');
+    expect(messages.join("\n")).not.toContain("private skipped text");
+    expect(messages.join("\n")).not.toContain("https://content.example.test/private.png");
+    expect(messages.join("\n")).not.toContain("private.png");
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(client.downloadAttachment).not.toHaveBeenCalled();
   });
 
   it("logs debug drop summary without attachment details", async () => {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -19,6 +19,8 @@ type FinalizeInboundContext =
 type DispatchReplyWithBufferedBlockDispatcher =
   typeof import("openclaw/plugin-sdk/reply-runtime")["dispatchReplyWithBufferedBlockDispatcher"];
 
+const warnedDropChatIds = new Set<string>();
+
 type ChannelRuntimeLike = {
   routing?: {
     resolveAgentRoute?: ResolveAgentRoute;
@@ -102,13 +104,13 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   const routeDescriptors = buildRouteDescriptors({ account, chatId, chatType });
   const groupConfig = account.config.groups?.[chatId];
   const threadFollowup = !!post.parentPostId && tracker.has(post.parentPostId);
-  const requireMention =
-    chatType === "direct"
-      ? false
-      : channelSetMatches(account.freeResponseChannels, chatId) ||
-          (threadFollowup && !account.threadRequireMention)
-        ? false
-        : groupConfig?.requireMention ?? account.requireMention;
+  const requireMention = resolveRequireMention({
+    account,
+    chatId,
+    chatType,
+    groupConfigRequireMention: groupConfig?.requireMention,
+    threadFollowup,
+  });
   const allowFrom = buildAllowFrom({
     account,
     ownerPersonId: inCtx.ownerPersonId,
@@ -155,7 +157,21 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     if (account.debugInboundMessages) {
       logInboundDropDebug(log, {
         chatId,
+        chatType,
+        groupConfigRequireMention: groupConfig?.requireMention,
+        groupPolicy: account.groupPolicy,
         reasonCode: ingress.ingress.reasonCode,
+        requireMention,
+        textLength: text.length,
+      });
+    } else {
+      logFirstInboundDropWarning(log, {
+        chatId,
+        chatType,
+        groupConfigRequireMention: groupConfig?.requireMention,
+        groupPolicy: account.groupPolicy,
+        reasonCode: ingress.ingress.reasonCode,
+        requireMention,
         textLength: text.length,
       });
     }
@@ -510,17 +526,80 @@ function logInboundDropDebug(
   log: (message: string) => void,
   details: {
     chatId: string;
+    chatType: ChatType;
+    groupConfigRequireMention?: boolean;
+    groupPolicy: string;
     reasonCode: string;
+    requireMention: boolean;
     textLength: number;
   },
 ): void {
   log(
     `[ringcentral] inbound message dropped ${JSON.stringify({
       chatId: details.chatId,
+      chatType: details.chatType,
+      groupConfigRequireMention: details.groupConfigRequireMention,
+      groupPolicy: details.groupPolicy,
       reasonCode: details.reasonCode,
+      requireMention: details.requireMention,
       textLength: details.textLength,
     })}`,
   );
+}
+
+function logFirstInboundDropWarning(
+  log: (message: string) => void,
+  details: {
+    chatId: string;
+    chatType: ChatType;
+    groupConfigRequireMention?: boolean;
+    groupPolicy: string;
+    reasonCode: string;
+    requireMention: boolean;
+    textLength: number;
+  },
+): void {
+  if (warnedDropChatIds.has(details.chatId)) {
+    return;
+  }
+  warnedDropChatIds.add(details.chatId);
+  log(
+    `[ringcentral] WARN inbound message dropped ${JSON.stringify({
+      chatId: details.chatId,
+      chatType: details.chatType,
+      groupConfigRequireMention: details.groupConfigRequireMention,
+      groupPolicy: details.groupPolicy,
+      reasonCode: details.reasonCode,
+      requireMention: details.requireMention,
+      textLength: details.textLength,
+      debugHint: "set debugInboundMessages=true for message text and drop details",
+    })}`,
+  );
+}
+
+function resolveRequireMention(params: {
+  account: ResolvedAccount;
+  chatId: string;
+  chatType: ChatType;
+  groupConfigRequireMention?: boolean;
+  threadFollowup: boolean;
+}): boolean {
+  if (params.chatType === "direct") {
+    return false;
+  }
+  if (
+    channelSetMatches(params.account.freeResponseChannels, params.chatId) ||
+    (params.threadFollowup && !params.account.threadRequireMention)
+  ) {
+    return false;
+  }
+  if (params.groupConfigRequireMention !== undefined) {
+    return params.groupConfigRequireMention;
+  }
+  if (params.account.requireMentionExplicit) {
+    return params.account.requireMention;
+  }
+  return params.account.groupPolicy === "open" ? false : params.account.requireMention;
 }
 
 async function getChatSafe(client: RingCentralClient, chatId: string): Promise<Chat | null> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,7 @@ export interface ResolvedAccount {
   noThreadChannels: string[];
   replyToMode: RingCentralReplyToMode;
   requireMention: boolean;
+  requireMentionExplicit: boolean;
   threadRequireMention: boolean;
   groupPolicy: "disabled" | "allowlist" | "open";
   dmPolicy: "disabled" | "allowlist" | "pairing" | "open";


### PR DESCRIPTION
## Summary
- add channelConfigs.ringcentral metadata so OpenClaw setup/doctor can discover RingCentral channel config before runtime loads
- keep channel schema/uiHints mirrored with the existing top-level config schema for compatibility
- let groupPolicy=open accept plain group messages unless requireMention is explicitly configured globally or per group
- include resolved group policy/mention fields in debug drop summaries

Fixes #166

## Test Plan
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack:check
- git diff --check