### PR TITLE
Fix RingCentral placeholder cleanup diagnostics

### DIFF
--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -393,4 +393,93 @@ describe("handleInboundPost", () => {
       }),
     );
   });
+
+  it("logs placeholder update failures, retries cleanup, and sends fallback reply", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = makeRuntime();
+      const client = makeClient();
+      const log = vi.fn();
+      client.updatePost.mockRejectedValueOnce(new Error("edit race"));
+      client.deletePost.mockRejectedValueOnce(new Error("transient delete")).mockResolvedValueOnce(undefined);
+      runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params: any) => {
+        await params.dispatcherOptions.onReplyStart();
+        const delivered = params.dispatcherOptions.deliver({ text: "final reply" });
+        await vi.advanceTimersByTimeAsync(250);
+        await delivered;
+        return { queuedFinal: false, counts: {} };
+      });
+
+      await handleInboundPost({
+        post: makePost({ groupId: "placeholder-update-chat" }),
+        cfg: {},
+        botClient: client,
+        account: resolveAccount({
+          botToken: "bot",
+          groupPolicy: "open",
+          requireMention: false,
+        }),
+        botPersonId: "bot",
+        channelRuntime: runtime,
+        tracker: new ThreadParticipationTracker(),
+        log,
+      });
+
+      expect(client.updatePost).toHaveBeenCalledWith("placeholder-update-chat", "sent-1", "final reply");
+      expect(client.deletePost).toHaveBeenCalledTimes(2);
+      expect(client.sendPost).toHaveBeenNthCalledWith(1, "placeholder-update-chat", "👀", {
+        parentPostId: "p1",
+      });
+      expect(client.sendPost).toHaveBeenNthCalledWith(2, "placeholder-update-chat", "final reply", {
+        parentPostId: "p1",
+      });
+      const messages = loggedMessages(log);
+      expect(messages.some((message) => message.includes("failed to update placeholder"))).toBe(true);
+      expect(messages.join("\n")).toContain('"postId":"sent-1"');
+      expect(messages.join("\n")).toContain('"error":"Error: edit race"');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs stuck placeholders when cleanup retry is exhausted", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = makeRuntime();
+      const client = makeClient();
+      const log = vi.fn();
+      client.deletePost.mockRejectedValue(new Error("delete denied"));
+      runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params: any) => {
+        await params.dispatcherOptions.onReplyStart();
+        const delivered = params.dispatcherOptions.deliver({});
+        await vi.advanceTimersByTimeAsync(250);
+        await delivered;
+        return { queuedFinal: false, counts: {} };
+      });
+
+      await handleInboundPost({
+        post: makePost({ groupId: "placeholder-stuck-chat" }),
+        cfg: {},
+        botClient: client,
+        account: resolveAccount({
+          botToken: "bot",
+          groupPolicy: "open",
+          requireMention: false,
+        }),
+        botPersonId: "bot",
+        channelRuntime: runtime,
+        tracker: new ThreadParticipationTracker(),
+        log,
+      });
+
+      expect(client.deletePost).toHaveBeenCalledTimes(2);
+      const messages = loggedMessages(log);
+      expect(messages.some((message) => message.includes("placeholder stuck after delete retry"))).toBe(true);
+      expect(messages.join("\n")).toContain('"chatId":"placeholder-stuck-chat"');
+      expect(messages.join("\n")).toContain('"postId":"sent-1"');
+      expect(messages.join("\n")).toContain('"error":"Error: delete denied"');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -5,8 +5,8 @@ import type {
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundAttachmentsForAgent } from "./attachments.js";
-import type { RingCentralClient } from "./client.js";
-import { deleteMessage, sendMessage, sendTypingIndicator, updateMessage } from "./send.js";
+import { RingCentralApiError, type RingCentralClient } from "./client.js";
+import { sendMessage, sendTypingIndicator, updateMessage } from "./send.js";
 import { RINGCENTRAL_CHANNEL_ID } from "./shared.js";
 import { buildChannelTarget, buildDmTarget, buildGroupTarget } from "./targets.js";
 import { channelSetMatches, type ThreadParticipationTracker } from "./threading.js";
@@ -258,6 +258,7 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
       sourceThreadId: post.threadId,
       tracker,
       markOwnPost: inCtx.markOwnPost,
+      log,
     }),
   });
 }
@@ -317,6 +318,7 @@ function createDispatcherOptions(params: {
   sourceThreadId?: string | number | null;
   tracker: ThreadParticipationTracker;
   markOwnPost?: (postId: string) => void;
+  log: (message: string) => void;
 }) {
   let placeholderPostId: string | undefined;
   let placeholderTimer: ReturnType<typeof setTimeout> | undefined;
@@ -328,8 +330,14 @@ function createDispatcherOptions(params: {
   const clearPlaceholder = async () => {
     clearPlaceholderTimer();
     if (placeholderPostId) {
-      await deleteMessage(params.botClient, params.chatId, placeholderPostId);
+      const idToDelete = placeholderPostId;
       placeholderPostId = undefined;
+      await deletePlaceholderWithRetry({
+        botClient: params.botClient,
+        chatId: params.chatId,
+        postId: idToDelete,
+        log: params.log,
+      });
     }
   };
   const startPlaceholder = async () => {
@@ -351,14 +359,21 @@ function createDispatcherOptions(params: {
       },
     );
     if (placeholderPostId && params.account.processingPlaceholder.editDelaySeconds > 0) {
+      const idToUpdate = placeholderPostId;
       placeholderTimer = setTimeout(() => {
         void updateMessage(
           params.botClient,
           params.chatId,
-          placeholderPostId!,
+          idToUpdate,
           params.account.processingPlaceholder.delayedText,
           false,
-        ).catch(() => undefined);
+        ).catch((err) => {
+          logPlaceholderWarning(params.log, "failed to update delayed placeholder", {
+            chatId: params.chatId,
+            postId: idToUpdate,
+            error: formatPlaceholderError(err),
+          });
+        });
       }, params.account.processingPlaceholder.editDelaySeconds * 1000);
     }
   };
@@ -377,7 +392,12 @@ function createDispatcherOptions(params: {
             params.tracker.remember(placeholderPostId);
             params.markOwnPost?.(placeholderPostId);
             placeholderPostId = undefined;
-          } catch {
+          } catch (err) {
+            logPlaceholderWarning(params.log, "failed to update placeholder", {
+              chatId: params.chatId,
+              postId: placeholderPostId,
+              error: formatPlaceholderError(err),
+            });
             await clearPlaceholder();
             await sendReplyText(params, payload.text);
           }
@@ -406,6 +426,62 @@ function createDispatcherOptions(params: {
       console.error(`[ringcentral] ${info.kind} reply error:`, err);
     },
   };
+}
+
+async function deletePlaceholderWithRetry(params: {
+  botClient: RingCentralClient;
+  chatId: string;
+  postId: string;
+  log: (message: string) => void;
+}): Promise<void> {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      await params.botClient.deletePost(params.chatId, params.postId);
+      return;
+    } catch (err) {
+      if (attempt === 1) {
+        await sleep(250);
+        continue;
+      }
+      logPlaceholderWarning(params.log, "placeholder stuck after delete retry", {
+        chatId: params.chatId,
+        postId: params.postId,
+        error: formatPlaceholderError(err),
+      });
+    }
+  }
+}
+
+function logPlaceholderWarning(
+  log: (message: string) => void,
+  event: string,
+  details: {
+    chatId: string;
+    postId?: string;
+    error: string;
+  },
+): void {
+  log(
+    `[ringcentral] WARN ${event} ${JSON.stringify({
+      chatId: details.chatId,
+      postId: details.postId,
+      error: details.error,
+    })}`,
+  );
+}
+
+function formatPlaceholderError(err: unknown): string {
+  if (err instanceof RingCentralApiError) {
+    return `HTTP ${err.status}`;
+  }
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function sendReplyText(

--- a/src/send.test.ts
+++ b/src/send.test.ts
@@ -142,9 +142,15 @@ describe("deleteMessage", () => {
     expect((client as any).deletePost).toHaveBeenCalledWith("c1", "p1");
   });
 
-  it("swallows errors silently", async () => {
+  it("logs deletion failures without throwing", async () => {
     const client = createMockClient();
-    (client as any).deletePost.mockRejectedValueOnce(new Error("404"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    (client as any).deletePost.mockRejectedValueOnce(new RingCentralApiError(404, "not found"));
     await expect(deleteMessage(client, "c1", "p1")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[ringcentral] failed to delete post "));
+    expect(warn.mock.calls[0]?.[0]).toContain('"chatId":"c1"');
+    expect(warn.mock.calls[0]?.[0]).toContain('"postId":"p1"');
+    expect(warn.mock.calls[0]?.[0]).toContain('"error":"HTTP 404"');
+    warn.mockRestore();
   });
 });

--- a/src/send.ts
+++ b/src/send.ts
@@ -1,6 +1,6 @@
 // Outbound message delivery: text, media, placeholders, and owner fallback.
 
-import { isAuthzOrNotFoundError, type RingCentralClient } from "./client.js";
+import { isAuthzOrNotFoundError, RingCentralApiError, type RingCentralClient } from "./client.js";
 import { markdownToMiniMarkdown } from "./markdown.js";
 import { resolveReplyTransport, type ThreadParticipationTracker } from "./threading.js";
 import type { RingCentralReplyToMode } from "./types.js";
@@ -169,7 +169,23 @@ export async function deleteMessage(
 ): Promise<void> {
   try {
     await client.deletePost(chatId, postId);
-  } catch {
-    // ignore best-effort cleanup failures
+  } catch (err) {
+    console.warn(
+      `[ringcentral] failed to delete post ${JSON.stringify({
+        chatId,
+        postId,
+        error: formatSendError(err),
+      })}`,
+    );
   }
+}
+
+function formatSendError(err: unknown): string {
+  if (err instanceof RingCentralApiError) {
+    return `HTTP ${err.status}`;
+  }
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
 }


### PR DESCRIPTION
## Summary
- log deleteMessage failures instead of silently swallowing them
- make processing placeholder cleanup retry once before reporting a stuck placeholder
- log placeholder update and delayed-edit failures before falling back to a normal reply
- keep logs safe: no message text, attachment URLs, tokens, JWTs, or secrets

Fixes #168

## Test Plan
- pnpm typecheck
- pnpm vitest run src/send.test.ts src/inbound.test.ts
- pnpm test
- pnpm build
- pnpm pack:check
- git diff --check