### PR TITLE
Document recommended RingCentral agent binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,45 @@ Owner credentials for history/fallback:
 
 `credentials` is still accepted as a deprecated config alias for `ownerCredentials`.
 
+## Pair With A Dedicated Agent
+
+Route RingCentral traffic to its own agent instead of the default webchat/TUI
+agent. This keeps operator debugging history out of RingCentral conversations
+and prevents a global coding `tools.profile` from removing the optional
+`ringcentral_*` tools.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "your-default-model"
+    },
+    "list": [
+      { "id": "main", "default": true },
+      {
+        "id": "ringcentral-bot",
+        "tools": {
+          "profile": null
+        }
+      }
+    ]
+  },
+  "bindings": [
+    {
+      "agentId": "ringcentral-bot",
+      "match": {
+        "channel": "ringcentral"
+      }
+    }
+  ]
+}
+```
+
+`tools.profile: null` is intentional: the RingCentral agent should not inherit a
+global coding profile that removes channel tools such as
+`ringcentral_get_recent_messages`, `ringcentral_create_calendar_event`,
+`ringcentral_create_note`, or `ringcentral_create_adaptive_card`.
+
 ## Environment
 
 Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally ignored.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -511,6 +511,20 @@
     "ringcentral": {
       "label": "RingCentral",
       "description": "OpenClaw RingCentral Team Messaging channel plugin",
+      "recommendedAgent": {
+        "id": "ringcentral-bot",
+        "model": null,
+        "tools": {
+          "profile": null
+        },
+        "workspace": null
+      },
+      "binding": {
+        "agentId": "ringcentral-bot",
+        "match": {
+          "channel": "ringcentral"
+        }
+      },
       "schema": {
         "type": "object",
         "additionalProperties": false,

--- a/src/artifact-tools.test.ts
+++ b/src/artifact-tools.test.ts
@@ -47,6 +47,16 @@ describe("RingCentral artifact tools", () => {
     const manifest = JSON.parse(readFileSync("openclaw.plugin.json", "utf8"));
     expect(manifest.channelConfigs?.ringcentral).toMatchObject({
       label: "RingCentral",
+      recommendedAgent: {
+        id: "ringcentral-bot",
+        model: null,
+        tools: { profile: null },
+        workspace: null,
+      },
+      binding: {
+        agentId: "ringcentral-bot",
+        match: { channel: "ringcentral" },
+      },
       schema: manifest.configSchema,
       uiHints: manifest.uiHints,
     });


### PR DESCRIPTION
## Summary
- add raw channelConfigs.ringcentral recommendedAgent/binding metadata for a dedicated RingCentral agent
- document the recommended agents.list + bindings config so RingCentral traffic does not reuse the webchat/TUI main session
- call out tools.profile=null so the RingCentral agent keeps optional ringcentral_* tools instead of inheriting a global coding profile
- add a manifest test that locks the recommended metadata in place

Fixes #170

## Notes
- OpenClaw core currently normalizes channelConfigs down to known fields, so automatic setup/doctor consumption of recommendedAgent/binding needs a follow-up core change. This PR ships the plugin-side raw metadata and operator-facing config guidance.

## Test Plan
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack:check
- git diff --check