### PR TITLE
refactor: route typing-indicator lifecycle through OpenClaw TypingController

### DIFF
--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -394,55 +394,54 @@ describe("handleInboundPost", () => {
     );
   });
 
-  it("logs placeholder update failures, retries cleanup, and sends fallback reply", async () => {
-    vi.useFakeTimers();
-    try {
-      const runtime = makeRuntime();
-      const client = makeClient();
-      const log = vi.fn();
-      client.updatePost.mockRejectedValueOnce(new Error("edit race"));
-      client.deletePost.mockRejectedValueOnce(new Error("transient delete")).mockResolvedValueOnce(undefined);
-      runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params: any) => {
-        await params.dispatcherOptions.onReplyStart();
-        const delivered = params.dispatcherOptions.deliver({ text: "final reply" });
-        await vi.advanceTimersByTimeAsync(250);
-        await delivered;
-        return { queuedFinal: false, counts: {} };
-      });
+  it("onReplyStart posts the typing indicator and onCleanup deletes it; deliver only sends the actual reply", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const log = vi.fn();
+    runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params: any) => {
+      await params.dispatcherOptions.onReplyStart();
+      const delivered = params.dispatcherOptions.deliver({ text: "final reply" });
+      await delivered;
+      // TypingController.cleanup() drives the platform's `onCleanup` after dispatch idle.
+      await params.dispatcherOptions.onCleanup();
+      return { queuedFinal: false, counts: {} };
+    });
 
-      await handleInboundPost({
-        post: makePost({ groupId: "placeholder-update-chat" }),
-        cfg: {},
-        botClient: client,
-        account: resolveAccount({
-          botToken: "bot",
-          groupPolicy: "open",
-          requireMention: false,
-        }),
-        botPersonId: "bot",
-        channelRuntime: runtime,
-        tracker: new ThreadParticipationTracker(),
-        log,
-      });
+    await handleInboundPost({
+      post: makePost({ groupId: "typing-lifecycle-chat" }),
+      cfg: {},
+      botClient: client,
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        requireMention: false,
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log,
+    });
 
-      expect(client.updatePost).toHaveBeenCalledWith("placeholder-update-chat", "sent-1", "final reply");
-      expect(client.deletePost).toHaveBeenCalledTimes(2);
-      expect(client.sendPost).toHaveBeenNthCalledWith(1, "placeholder-update-chat", "👀", {
-        parentPostId: "p1",
-      });
-      expect(client.sendPost).toHaveBeenNthCalledWith(2, "placeholder-update-chat", "final reply", {
-        parentPostId: "p1",
-      });
-      const messages = loggedMessages(log);
-      expect(messages.some((message) => message.includes("failed to update placeholder"))).toBe(true);
-      expect(messages.join("\n")).toContain('"postId":"sent-1"');
-      expect(messages.join("\n")).toContain('"error":"Error: edit race"');
-    } finally {
-      vi.useRealTimers();
-    }
+    // 1. onReplyStart: post the 👀 once
+    expect(client.sendPost).toHaveBeenCalledTimes(2);
+    expect(client.sendPost).toHaveBeenNthCalledWith(1, "typing-lifecycle-chat", "\u{1F440}", {
+      parentPostId: "p1",
+    });
+    // 2. deliver: send the actual reply, do NOT touch the typing post
+    expect(client.updatePost).not.toHaveBeenCalled();
+    expect(client.sendPost).toHaveBeenNthCalledWith(2, "typing-lifecycle-chat", "final reply", {
+      parentPostId: "p1",
+    });
+    // 3. onCleanup: delete the typing post once
+    expect(client.deletePost).toHaveBeenCalledTimes(1);
+    expect(client.deletePost).toHaveBeenCalledWith("typing-lifecycle-chat", "sent-1");
+
+    const messages = loggedMessages(log);
+    expect(messages.some((m) => m.includes("created typing post postId=sent-1 chatId=typing-lifecycle-chat"))).toBe(true);
+    expect(messages.some((m) => m.includes("deleted typing post postId=sent-1 chatId=typing-lifecycle-chat"))).toBe(true);
   });
 
-  it("logs stuck placeholders when cleanup retry is exhausted", async () => {
+  it("onCleanup retries and warns when deletePost is persistently rejected", async () => {
     vi.useFakeTimers();
     try {
       const runtime = makeRuntime();
@@ -451,14 +450,16 @@ describe("handleInboundPost", () => {
       client.deletePost.mockRejectedValue(new Error("delete denied"));
       runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params: any) => {
         await params.dispatcherOptions.onReplyStart();
-        const delivered = params.dispatcherOptions.deliver({});
-        await vi.advanceTimersByTimeAsync(250);
+        const delivered = params.dispatcherOptions.deliver({ text: "final reply" });
         await delivered;
+        const cleanup = params.dispatcherOptions.onCleanup();
+        await vi.advanceTimersByTimeAsync(250);
+        await cleanup;
         return { queuedFinal: false, counts: {} };
       });
 
       await handleInboundPost({
-        post: makePost({ groupId: "placeholder-stuck-chat" }),
+        post: makePost({ groupId: "typing-stuck-chat" }),
         cfg: {},
         botClient: client,
         account: resolveAccount({
@@ -472,10 +473,11 @@ describe("handleInboundPost", () => {
         log,
       });
 
+      // Retry once, then give up; total 2 deletePost calls.
       expect(client.deletePost).toHaveBeenCalledTimes(2);
       const messages = loggedMessages(log);
-      expect(messages.some((message) => message.includes("placeholder stuck after delete retry"))).toBe(true);
-      expect(messages.join("\n")).toContain('"chatId":"placeholder-stuck-chat"');
+      expect(messages.some((message) => message.includes("typing post stuck after delete retry"))).toBe(true);
+      expect(messages.join("\n")).toContain('"chatId":"typing-stuck-chat"');
       expect(messages.join("\n")).toContain('"postId":"sent-1"');
       expect(messages.join("\n")).toContain('"error":"Error: delete denied"');
     } finally {

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -480,6 +480,7 @@ describe("handleInboundPost", () => {
       expect(messages.join("\n")).toContain('"chatId":"typing-stuck-chat"');
       expect(messages.join("\n")).toContain('"postId":"sent-1"');
       expect(messages.join("\n")).toContain('"error":"Error: delete denied"');
+      expect(messages.some((message) => message.includes("deleted typing post postId=sent-1"))).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -360,15 +360,17 @@ function createDispatcherOptions(params: {
     }
     const idToDelete = typingPostId;
     typingPostId = undefined;
-    await deleteTypingPostWithRetry({
+    const deleted = await deleteTypingPostWithRetry({
       botClient: params.botClient,
       chatId: params.chatId,
       postId: idToDelete,
       log: params.log,
     });
-    params.log(
-      `[ringcentral] deleted typing post postId=${idToDelete} chatId=${params.chatId}`,
-    );
+    if (deleted) {
+      params.log(
+        `[ringcentral] deleted typing post postId=${idToDelete} chatId=${params.chatId}`,
+      );
+    }
   };
 
   return {
@@ -408,11 +410,11 @@ async function deleteTypingPostWithRetry(params: {
   chatId: string;
   postId: string;
   log: (message: string) => void;
-}): Promise<void> {
+}): Promise<boolean> {
   for (let attempt = 1; attempt <= 2; attempt += 1) {
     try {
       await params.botClient.deletePost(params.chatId, params.postId);
-      return;
+      return true;
     } catch (err) {
       if (attempt === 1) {
         await sleep(250);
@@ -425,6 +427,7 @@ async function deleteTypingPostWithRetry(params: {
       });
     }
   }
+  return false;
 }
 
 function logTypingPostWarning(

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -6,7 +6,7 @@ import type {
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundAttachmentsForAgent } from "./attachments.js";
 import { RingCentralApiError, type RingCentralClient } from "./client.js";
-import { sendMessage, sendTypingIndicator, updateMessage } from "./send.js";
+import { sendMessage, sendTypingIndicator } from "./send.js";
 import { RINGCENTRAL_CHANNEL_ID } from "./shared.js";
 import { buildChannelTarget, buildDmTarget, buildGroupTarget } from "./targets.js";
 import { channelSetMatches, type ThreadParticipationTracker } from "./threading.js";
@@ -320,31 +320,19 @@ function createDispatcherOptions(params: {
   markOwnPost?: (postId: string) => void;
   log: (message: string) => void;
 }) {
-  let placeholderPostId: string | undefined;
-  let placeholderTimer: ReturnType<typeof setTimeout> | undefined;
+  // Typing-indicator lifecycle is owned by the OpenClaw `TypingController`:
+  //   - `onReplyStart`  (called by `TypingController.startTypingLoop`) posts the 👀
+  //   - `onCleanup`     (called by `TypingController.cleanup` after dispatch idle) deletes it
+  // `deliver` no longer mutates the typing post — it only sends the actual reply.
+  // The previous `placeholderTimer` setTimeout + `deliver`-side `updateMessage` →
+  // `payload.text` rewrite are gone; see #173 for the rationale.
+  let typingPostId: string | undefined;
 
-  const clearPlaceholderTimer = () => {
-    clearTimeout(placeholderTimer);
-    placeholderTimer = undefined;
-  };
-  const clearPlaceholder = async () => {
-    clearPlaceholderTimer();
-    if (placeholderPostId) {
-      const idToDelete = placeholderPostId;
-      placeholderPostId = undefined;
-      await deletePlaceholderWithRetry({
-        botClient: params.botClient,
-        chatId: params.chatId,
-        postId: idToDelete,
-        log: params.log,
-      });
-    }
-  };
-  const startPlaceholder = async () => {
-    if (!params.account.processingPlaceholder.enabled || placeholderPostId) {
+  const startTypingPost = async () => {
+    if (!params.account.processingPlaceholder.enabled || typingPostId) {
       return;
     }
-    placeholderPostId = await sendTypingIndicator(
+    const newId = await sendTypingIndicator(
       params.botClient,
       params.chatId,
       params.account.processingPlaceholder.initialText,
@@ -358,54 +346,41 @@ function createDispatcherOptions(params: {
         markOwnPost: params.markOwnPost,
       },
     );
-    if (placeholderPostId && params.account.processingPlaceholder.editDelaySeconds > 0) {
-      const idToUpdate = placeholderPostId;
-      placeholderTimer = setTimeout(() => {
-        void updateMessage(
-          params.botClient,
-          params.chatId,
-          idToUpdate,
-          params.account.processingPlaceholder.delayedText,
-          false,
-        ).catch((err) => {
-          logPlaceholderWarning(params.log, "failed to update delayed placeholder", {
-            chatId: params.chatId,
-            postId: idToUpdate,
-            error: formatPlaceholderError(err),
-          });
-        });
-      }, params.account.processingPlaceholder.editDelaySeconds * 1000);
+    if (newId) {
+      typingPostId = newId;
+      params.log(
+        `[ringcentral] created typing post postId=${newId} chatId=${params.chatId}`,
+      );
     }
   };
 
+  const clearTypingPost = async () => {
+    if (!typingPostId) {
+      return;
+    }
+    const idToDelete = typingPostId;
+    typingPostId = undefined;
+    await deleteTypingPostWithRetry({
+      botClient: params.botClient,
+      chatId: params.chatId,
+      postId: idToDelete,
+      log: params.log,
+    });
+    params.log(
+      `[ringcentral] deleted typing post postId=${idToDelete} chatId=${params.chatId}`,
+    );
+  };
+
   return {
-    onReplyStart: startPlaceholder,
+    onReplyStart: startTypingPost,
     onCleanup: () => {
-      void clearPlaceholder();
+      void clearTypingPost();
     },
     deliver: async (payload: ReplyPayload) => {
-      clearPlaceholderTimer();
+      // Typing-indicator cleanup is the platform's job, not deliver's.
+      // deliver just sends the actual reply (and any media).
       if (payload.text) {
-        if (placeholderPostId) {
-          try {
-            await updateMessage(params.botClient, params.chatId, placeholderPostId, payload.text);
-            params.tracker.remember(placeholderPostId);
-            params.markOwnPost?.(placeholderPostId);
-            placeholderPostId = undefined;
-          } catch (err) {
-            logPlaceholderWarning(params.log, "failed to update placeholder", {
-              chatId: params.chatId,
-              postId: placeholderPostId,
-              error: formatPlaceholderError(err),
-            });
-            await clearPlaceholder();
-            await sendReplyText(params, payload.text);
-          }
-        } else {
-          await sendReplyText(params, payload.text);
-        }
-      } else if (placeholderPostId) {
-        await clearPlaceholder();
+        await sendReplyText(params, payload.text);
       }
       if (payload.mediaUrl) {
         await sendMessage({
@@ -428,7 +403,7 @@ function createDispatcherOptions(params: {
   };
 }
 
-async function deletePlaceholderWithRetry(params: {
+async function deleteTypingPostWithRetry(params: {
   botClient: RingCentralClient;
   chatId: string;
   postId: string;
@@ -443,16 +418,16 @@ async function deletePlaceholderWithRetry(params: {
         await sleep(250);
         continue;
       }
-      logPlaceholderWarning(params.log, "placeholder stuck after delete retry", {
+      logTypingPostWarning(params.log, "typing post stuck after delete retry", {
         chatId: params.chatId,
         postId: params.postId,
-        error: formatPlaceholderError(err),
+        error: formatTypingPostError(err),
       });
     }
   }
 }
 
-function logPlaceholderWarning(
+function logTypingPostWarning(
   log: (message: string) => void,
   event: string,
   details: {
@@ -470,7 +445,7 @@ function logPlaceholderWarning(
   );
 }
 
-function formatPlaceholderError(err: unknown): string {
+function formatTypingPostError(err: unknown): string {
   if (err instanceof RingCentralApiError) {
     return `HTTP ${err.status}`;
   }


### PR DESCRIPTION
Fixes #173.

## Summary

Replace the ad-hoc `processingPlaceholder` mechanism in `createDispatcherOptions` with a clean two-state flow owned by OpenClaw's `TypingController`:

- `onReplyStart` (called by `TypingController.startTypingLoop`) posts the `initialText` 👀 and stores its `postId` in a closure. The manual `setTimeout(editDelaySeconds)` that previously updated the post to `delayedText` is gone — `TypingController.startTypingOnText` is the only refresh path the platform drives, and it doesn't carry text into our callback, so preview text is no longer supported. Static `initialText` (default `"👀"`) is now the only mode.
- `onCleanup` (called by `TypingController.cleanup` after dispatch idle) deletes the post via `deleteTypingPostWithRetry`, which keeps the retry + WARN logging from #169.
- `deliver` no longer mutates the typing post. It only sends the actual reply. The previous `updateMessage(placeholderPostId, payload.text)` attempt to convert the 👀 into the reply in place is gone. The bot's visible behavior is now: 👀 appears → reply appears → 👀 disappears (after platform's 10s dispatch-idle grace).

## Why this fixes the leak

The previous hand-stitched `onCleanup` was one of many possible dispatcher exit paths. If the dispatcher ended via a path that didn't propagate to our `onCleanup` (agent instance crash, dispatcher timeout, etc.) the 👀/⏳ was stranded in the chat. With the `TypingController` wiring, the platform's `cleanup` is called by the dispatch-idle state machine, which is the strongest possible cleanup guarantee short of a process-level force-cleanup at next agent-instance GC.

## Other changes

- Renamed: `deletePlaceholderWithRetry` → `deleteTypingPostWithRetry`, `logPlaceholderWarning` → `logTypingPostWarning`, `formatPlaceholderError` → `formatTypingPostError`. The WARN strings now say `"typing post"` instead of `"placeholder"`.
- Added success-path logs:
  - `[ringcentral] created typing post postId=... chatId=...`
  - `[ringcentral] deleted typing post postId=... chatId=...`
  These make it possible to verify the lifecycle end-to-end from the gateway log.
- Removed the unused `updateMessage` import.

## Backward compatibility

The `processingPlaceholder` config block is unchanged on the wire (`.enabled` / `.initialText`). The previous `delayedText` / `editDelaySeconds` fields are still accepted but ignored — documented behavior for backward compatibility. A future PR can mark them `@deprecated` in the schema and the resolver if desired.

## Test plan

- `pnpm typecheck` — pass
- `pnpm test` — pass (203 / 204, 1 skipped live-smoke)
- `pnpm build` — pass

Tests in `src/inbound.test.ts` rewritten to drive the new lifecycle:
- `onReplyStart posts the typing indicator and onCleanup deletes it; deliver only sends the actual reply` — verifies the post-then-delete flow, asserts `updatePost` is *not* called, asserts the new success-path logs fire.
- `onCleanup retries and warns when deletePost is persistently rejected` — covers the retry path with `vi.advanceTimersByTimeAsync(250)` between the two delete attempts.

## Verification (post-merge)

1. Cut `main` → `pnpm build` → `openclaw gateway restart`
2. Send a `@mention` into the configured group
3. In the gateway log, expect:
   - `created typing post postId=... chatId=...`
   - `deleted typing post postId=... chatId=...` (after the 10s dispatch-idle grace)
4. In the RC client, the chat contains **only** the agent's reply; no leftover 👀/⏳.