### PR TITLE
Improve RingCentral thread follow-up diagnostics

### DIFF
--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -167,6 +167,79 @@ describe("handleInboundPost", () => {
     expect(drop).toContain('"requireMention":true');
   });
 
+  it("treats tracked RingCentral thread ids as thread follow-ups without another mention", async () => {
+    const runtime = makeRuntime();
+    const tracker = new ThreadParticipationTracker();
+    tracker.remember("bot-reply", "thread-root");
+
+    await handleInboundPost({
+      post: makePost({
+        parentPostId: undefined,
+        threadId: "thread-root",
+        text: "thread follow-up without mention",
+      }),
+      cfg: {},
+      botClient: makeClient(),
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        requireMention: true,
+        threadRequireMention: false,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker,
+    });
+
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("logs accepted dispatch start, still-pending, and complete diagnostics", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = makeRuntime();
+      const log = vi.fn();
+      let resolveDispatch: ((value: { queuedFinal: boolean; counts: Record<string, never> }) => void) | undefined;
+      runtime.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveDispatch = resolve;
+          }),
+      );
+
+      const pending = handleInboundPost({
+        post: makePost({ groupId: "pending-chat", threadId: "thread-root" }),
+        cfg: {},
+        botClient: makeClient(),
+        account: resolveAccount({
+          botToken: "bot",
+          groupPolicy: "open",
+          requireMention: false,
+          processingPlaceholder: { enabled: false },
+        }),
+        botPersonId: "bot",
+        channelRuntime: runtime,
+        tracker: new ThreadParticipationTracker(),
+        log,
+      });
+
+      await vi.waitFor(() => {
+        expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+      });
+      expect(loggedMessages(log).some((message) => message.startsWith("[ringcentral] inbound dispatch start "))).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(loggedMessages(log).some((message) => message.startsWith("[ringcentral] inbound dispatch still_pending "))).toBe(true);
+
+      resolveDispatch?.({ queuedFinal: false, counts: {} });
+      await pending;
+      expect(loggedMessages(log).some((message) => message.startsWith("[ringcentral] inbound dispatch complete "))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not log inbound message text by default", async () => {
     const runtime = makeRuntime();
     const log = vi.fn();

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -71,6 +71,7 @@ const identity = {
 const RC_TYPED_MENTION_RE = /!\[:(?<type>[A-Za-z]+)\]\((?<id>[^)]+)\)/g;
 const RC_LEADING_TYPED_MENTION_RE = /^!\[:(?<type>[A-Za-z]+)\]\((?<id>[^)]+)\)\s*/;
 const TYPING_POST_FAILSAFE_TTL_MS = 2 * 60_000;
+const DISPATCH_START_WARN_MS = 5_000;
 
 const personCache = new Map<string, PersonInfo | null>();
 
@@ -104,7 +105,7 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   });
   const routeDescriptors = buildRouteDescriptors({ account, chatId, chatType });
   const groupConfig = account.config.groups?.[chatId];
-  const threadFollowup = !!post.parentPostId && tracker.has(post.parentPostId);
+  const threadFollowup = isTrackedThreadFollowup(post, tracker);
   const requireMention = resolveRequireMention({
     account,
     chatId,
@@ -247,21 +248,66 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     ...mediaPayload,
   });
 
-  await dispatchReplyWithBufferedBlockDispatcher({
-    ctx: context,
-    cfg,
-    dispatcherOptions: createDispatcherOptions({
-      botClient,
-      ownerClient,
-      account,
+  const dispatchWarnTimer = setTimeout(() => {
+    logInboundDispatchDiagnostic(log, "still_pending", {
       chatId,
-      sourcePostId: post.id,
-      sourceThreadId: post.threadId,
-      tracker,
-      markOwnPost: inCtx.markOwnPost,
-      log,
-    }),
+      postId: post.id,
+      parentPostId: post.parentPostId,
+      threadId: post.threadId,
+      routeSessionKey: route.sessionKey,
+    });
+  }, DISPATCH_START_WARN_MS);
+  dispatchWarnTimer.unref?.();
+  logInboundDispatchDiagnostic(log, "start", {
+    chatId,
+    postId: post.id,
+    parentPostId: post.parentPostId,
+    threadId: post.threadId,
+    routeSessionKey: route.sessionKey,
   });
+  try {
+    await dispatchReplyWithBufferedBlockDispatcher({
+      ctx: context,
+      cfg,
+      dispatcherOptions: createDispatcherOptions({
+        botClient,
+        ownerClient,
+        account,
+        chatId,
+        sourcePostId: post.id,
+        sourceThreadId: post.threadId,
+        tracker,
+        markOwnPost: inCtx.markOwnPost,
+        log,
+      }),
+    });
+    logInboundDispatchDiagnostic(log, "complete", {
+      chatId,
+      postId: post.id,
+      parentPostId: post.parentPostId,
+      threadId: post.threadId,
+      routeSessionKey: route.sessionKey,
+    });
+  } catch (err) {
+    logInboundDispatchDiagnostic(log, "failed", {
+      chatId,
+      postId: post.id,
+      parentPostId: post.parentPostId,
+      threadId: post.threadId,
+      routeSessionKey: route.sessionKey,
+      error: formatTypingPostError(err),
+    });
+    throw err;
+  } finally {
+    clearTimeout(dispatchWarnTimer);
+  }
+}
+
+function isTrackedThreadFollowup(post: Post, tracker: ThreadParticipationTracker): boolean {
+  return Boolean(
+    (post.parentPostId && (tracker.has(post.parentPostId) || tracker.hasThread(post.parentPostId))) ||
+      (post.threadId && tracker.hasThread(post.threadId)),
+  );
 }
 
 export function stripRcMentions(
@@ -681,6 +727,30 @@ function logFirstInboundDropWarning(
       requireMention: details.requireMention,
       textLength: details.textLength,
       debugHint: "set debugInboundMessages=true for message text and drop details",
+    })}`,
+  );
+}
+
+function logInboundDispatchDiagnostic(
+  log: (message: string) => void,
+  event: "start" | "still_pending" | "complete" | "failed",
+  details: {
+    chatId: string;
+    postId: string;
+    parentPostId?: string;
+    threadId?: string;
+    routeSessionKey: string;
+    error?: string;
+  },
+): void {
+  log(
+    `[ringcentral] inbound dispatch ${event} ${JSON.stringify({
+      chatId: details.chatId,
+      postId: details.postId,
+      parentPostId: details.parentPostId,
+      threadId: details.threadId,
+      routeSessionKey: details.routeSessionKey,
+      error: details.error,
     })}`,
   );
 }

--- a/src/send.test.ts
+++ b/src/send.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { sendMessage, sendTypingIndicator, updateMessage, deleteMessage } from "./send.js";
 import { RingCentralApiError, type RingCentralClient } from "./client.js";
+import { ThreadParticipationTracker } from "./threading.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -38,6 +39,22 @@ describe("sendMessage", () => {
     expect((client as any).sendPost).toHaveBeenCalledWith("c1", "reply", {
       parentPostId: "p-parent",
     });
+  });
+
+  it("remembers the root thread when sending a threaded reply", async () => {
+    const client = createMockClient();
+    const tracker = new ThreadParticipationTracker();
+
+    await sendMessage({
+      client,
+      chatId: "c1",
+      text: "reply",
+      replyToId: "p-parent",
+      tracker,
+    });
+
+    expect(tracker.has("post1")).toBe(true);
+    expect(tracker.hasThread("p-parent")).toBe(true);
   });
 
   it("uses fallback client on authz failures", async () => {

--- a/src/send.ts
+++ b/src/send.ts
@@ -43,7 +43,7 @@ export async function sendMessage(opts: SendOptions): Promise<{ postId: string; 
     tracker: opts.tracker,
   });
   const post = await sendPostWithFallback(opts, finalText, transport);
-  opts.tracker?.remember(post.id);
+  opts.tracker?.remember(post.id, threadIdForParticipation(post, transport));
   opts.markOwnPost?.(post.id);
   return { postId: post.id, raw: post };
 }
@@ -61,12 +61,27 @@ async function sendMediaMessage(opts: SendOptions): Promise<{ postId: string; ra
     const contentType = resp.headers.get("content-type") ?? "application/octet-stream";
     const ext = contentType.includes("png") ? "png" : contentType.includes("gif") ? "gif" : "jpg";
     const post = await uploadWithFallback(opts, `image.${ext}`, buf, contentType);
-    opts.tracker?.remember(post.id);
+    const transport = resolveReplyTransport({
+      chatId: opts.chatId,
+      replyToId: opts.replyToId,
+      threadId: opts.threadId,
+      replyToMode: opts.replyToMode ?? "first",
+      noThreadChannels: opts.noThreadChannels,
+      tracker: opts.tracker,
+    });
+    opts.tracker?.remember(post.id, threadIdForParticipation(post, transport));
     opts.markOwnPost?.(post.id);
     return { postId: post.id, raw: post };
   } catch {
     return null;
   }
+}
+
+function threadIdForParticipation(
+  post: { threadId?: string | number | null; parentPostId?: string | number | null },
+  transport: { parentPostId?: string | number; threadId?: string | number },
+): string | number | undefined {
+  return post.threadId ?? transport.threadId ?? transport.parentPostId ?? post.parentPostId ?? undefined;
 }
 
 async function sendPostWithFallback(

--- a/src/threading.test.ts
+++ b/src/threading.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveReplyTransport, ThreadParticipationTracker } from "./threading.js";
+
+describe("ThreadParticipationTracker", () => {
+  it("tracks bot post ids and related thread ids", () => {
+    const tracker = new ThreadParticipationTracker();
+
+    tracker.remember("bot-reply", "root-thread");
+
+    expect(tracker.has("bot-reply")).toBe(true);
+    expect(tracker.hasThread("root-thread")).toBe(true);
+    expect(tracker.has("root-thread")).toBe(false);
+  });
+
+  it("can track thread ids without a bot post id", () => {
+    const tracker = new ThreadParticipationTracker();
+
+    tracker.rememberThread("root-thread");
+
+    expect(tracker.hasThread("root-thread")).toBe(true);
+  });
+});
+
+describe("resolveReplyTransport", () => {
+  it("does not thread first-mode replies when replying to a tracked bot post", () => {
+    const tracker = new ThreadParticipationTracker();
+    tracker.remember("bot-reply", "root-thread");
+
+    expect(
+      resolveReplyTransport({
+        chatId: "chat",
+        replyToId: "bot-reply",
+        replyToMode: "first",
+        tracker,
+      }),
+    ).toEqual({});
+  });
+
+  it("uses RingCentral threadId when it is available", () => {
+    const tracker = new ThreadParticipationTracker();
+    tracker.remember("bot-reply", "root-thread");
+
+    expect(
+      resolveReplyTransport({
+        chatId: "chat",
+        replyToId: "bot-reply",
+        threadId: "root-thread",
+        replyToMode: "first",
+        tracker,
+      }),
+    ).toEqual({ threadId: "root-thread" });
+  });
+});

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -2,15 +2,32 @@ import type { RingCentralReplyToMode } from "./types.js";
 
 export class ThreadParticipationTracker {
   private readonly sentPostIds = new Set<string>();
+  private readonly threadIds = new Set<string>();
 
-  remember(postId: string | undefined | null): void {
+  remember(
+    postId: string | undefined | null,
+    threadId?: string | number | undefined | null,
+  ): void {
     if (postId) {
-      this.sentPostIds.add(postId);
+      this.sentPostIds.add(String(postId));
+    }
+    if (threadId) {
+      this.threadIds.add(String(threadId));
     }
   }
 
-  has(postId: string | undefined | null): boolean {
-    return !!postId && this.sentPostIds.has(postId);
+  rememberThread(threadId: string | number | undefined | null): void {
+    if (threadId) {
+      this.threadIds.add(String(threadId));
+    }
+  }
+
+  has(postId: string | number | undefined | null): boolean {
+    return !!postId && this.sentPostIds.has(String(postId));
+  }
+
+  hasThread(threadId: string | number | undefined | null): boolean {
+    return !!threadId && this.threadIds.has(String(threadId));
   }
 }
 


### PR DESCRIPTION
Addresses #178.

## Summary

Improve RingCentral thread follow-up handling and add explicit diagnostics for the "accepted inbound message but no visible agent run" failure mode.

This PR intentionally does **not** close #178 because durable tracker persistence across gateway restarts is still a separate design decision. It does fix the in-memory `threadId` blind spot and makes downstream dispatch stalls visible in logs.

## What Changed

- `ThreadParticipationTracker` now tracks both:
  - bot reply post IDs;
  - RingCentral thread/root IDs.
- Thread follow-up detection now accepts either:
  - `parentPostId` matching a tracked bot post/root thread; or
  - `threadId` matching a tracked RingCentral thread/root.
- Successful threaded sends remember the related thread/root ID, using RingCentral response metadata when available and falling back to the request transport.
- Accepted inbound messages now log dispatch lifecycle diagnostics:
  - `inbound dispatch start`
  - `inbound dispatch still_pending` after 5 seconds
  - `inbound dispatch complete`
  - `inbound dispatch failed`

The diagnostics include chat/post/thread IDs and the resolved route session key, but do not log message text or credentials.

## Why

#178 showed two useful facts:

1. A mention message could pass ingress admission but then produce no visible agent run, typing post, or reply.
2. A later thread reply could be dropped as `activation_skipped` because the tracker only checked `parentPostId` against bot-sent post IDs.

If RingCentral sends thread replies with `threadId`, or if the useful root marker is not the exact bot post ID, the previous tracker could miss valid follow-ups. This PR makes the tracker aware of the RingCentral thread/root dimension and logs the dispatch boundary so we can distinguish ingress drops from downstream OpenClaw dispatch stalls.

## Out Of Scope

- Persistent tracker storage across gateway restarts.
- Stale OpenClaw session lock cleanup.
- Changing `threadRequireMention` defaults.

Those are still valid follow-up areas for #178, but they need a separate state/storage design instead of being bundled into this focused fix.

## Tests

Added/updated tests for:

- tracking bot post IDs and RingCentral thread IDs;
- `resolveReplyTransport` behavior with tracked posts and explicit `threadId`;
- remembering root/thread IDs after threaded sends;
- admitting thread follow-ups by tracked `threadId` when `threadRequireMention=false`;
- logging dispatch start/still-pending/complete diagnostics.

## Verification

- `pnpm vitest run src/threading.test.ts src/send.test.ts src/inbound.test.ts`
- `pnpm typecheck`
- `git diff --check`
