### PR TITLE
Add optional RingCentral thread follow-up live smoke

### DIFF
--- a/.github/workflows/ringcentral-live-smoke.yml
+++ b/.github/workflows/ringcentral-live-smoke.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: true
+      thread_followup:
+        description: "Run optional threaded follow-up smoke"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   ringcentral-live-smoke:
@@ -43,6 +48,7 @@ jobs:
       RC_E2E_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == true && 'true' || 'false' }}
       RC_E2E_WS_TIMEOUT_MS: ${{ inputs.ws_timeout_ms || '30000' }}
       RC_E2E_FILE_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.file_upload == false && 'false' || 'true' }}
+      RC_E2E_THREAD_FOLLOWUP: ${{ github.event_name == 'workflow_dispatch' && inputs.thread_followup == true && 'true' || 'false' }}
       RC_E2E_SOURCE_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
       RC_E2E_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RC_BOT_TOKEN: ${{ secrets.RC_BOT_TOKEN }}

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -96,6 +96,14 @@ liveDescribe("RingCentral live smoke", () => {
         createdBotPostIds,
         createdOwnerPostIds,
       });
+      await runThreadFollowupScenario({
+        env,
+        botClient,
+        ownerClient,
+        botExtension,
+        createdBotPostIds,
+        createdOwnerPostIds,
+      });
       await runCalendarEventScenario({
         env,
         ownerClient,
@@ -166,6 +174,7 @@ interface LiveEnv {
   cleanup: boolean;
   wsTimeoutMs: number;
   fileUpload: boolean;
+  threadFollowup: boolean;
 }
 
 interface LiveClients {
@@ -280,6 +289,7 @@ function buildSummaryContext(env: LiveEnv): Record<string, SummaryDetail> {
     record_count: env.recordCount,
     ws_timeout_ms: env.wsTimeoutMs,
     file_upload: env.fileUpload,
+    thread_followup: env.threadFollowup,
   };
 }
 
@@ -293,6 +303,7 @@ function buildBaseSummaryContext(): Record<string, SummaryDetail> {
     record_count: readRecordCount(),
     ws_timeout_ms: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
     file_upload: readBooleanEnv("RC_E2E_FILE_UPLOAD", true),
+    thread_followup: readBooleanEnv("RC_E2E_THREAD_FOLLOWUP", false),
   };
 }
 
@@ -540,6 +551,119 @@ async function runThreadedReplyScenario(
   logSafe("owner_read_thread_reply", { owner_read_found: true, thread_metadata: true });
 }
 
+async function runThreadFollowupScenario(
+  params: LiveClients & {
+    botExtension: ExtensionInfo;
+    createdOwnerPostIds: string[];
+  },
+): Promise<void> {
+  if (!params.env.threadFollowup) {
+    logSafe("thread_followup", { enabled: false });
+    return;
+  }
+
+  const rootText = buildUniqueText("thread-followup-root");
+  const rootReplyText = buildUniqueText("thread-followup-root-reply");
+  const followupText = buildUniqueText("thread-followup-owner");
+  const followupReplyText = buildUniqueText("thread-followup-bot-reply");
+  const wsWaiter = startBotWebSocketWait({
+    botClient: params.botClient,
+    botPersonId: String(params.botExtension.id ?? ""),
+    chatId: params.env.chatId,
+    expectedText: followupText,
+    timeoutMs: params.env.wsTimeoutMs,
+  });
+
+  try {
+    await liveStep("thread_followup_ws_connect", () =>
+      withTimeout(wsWaiter.connected, params.env.wsTimeoutMs, "thread_followup_ws_connect"),
+    );
+
+    const root = await liveStep("thread_root_send", () =>
+      params.ownerClient.sendPost(params.env.chatId, rootText),
+    );
+    assertLive(!!root.id, "thread_root_send");
+    const rootId = String(root.id);
+    params.createdOwnerPostIds.push(rootId);
+    logSafe("thread_root_send", { sent: true });
+
+    const rootReply = await liveStep("bot_thread_root_reply", () =>
+      sendMessage({
+        client: params.botClient,
+        chatId: params.env.chatId,
+        text: rootReplyText,
+        convertMarkdown: false,
+        replyToId: rootId,
+      }),
+    );
+    assertLive(!!rootReply?.postId, "bot_thread_root_reply");
+    params.createdBotPostIds.push(rootReply!.postId);
+    logSafe("bot_thread_root_reply", { sent: true });
+
+    const followup = await liveStep("owner_thread_followup_send", () =>
+      params.ownerClient.sendPost(params.env.chatId, followupText, { parentPostId: rootId }),
+    );
+    assertLive(!!followup.id, "owner_thread_followup_send");
+    params.createdOwnerPostIds.push(String(followup.id));
+    logSafe("owner_thread_followup_send", { sent: true });
+
+    const received = await liveStep("bot_ws_thread_followup_receive", () =>
+      withTimeout(wsWaiter.received, params.env.wsTimeoutMs, "bot_ws_thread_followup_receive"),
+    );
+    assertLive(
+      received.groupId === params.env.chatId &&
+        !!received.text?.includes(followupText) &&
+        hasThreadMetadata(received, rootId),
+      "bot_ws_thread_followup_receive",
+    );
+    logSafe("bot_ws_thread_followup_receive", {
+      ws_received: true,
+      thread_metadata: true,
+    });
+
+    const botRead = await liveStep("bot_read_thread_followup", () =>
+      waitForPost(params.botClient, params.env.chatId, followupText, params.env.recordCount),
+    );
+    assertLive(
+      botRead?.id === followup.id &&
+        !!botRead?.text?.includes(followupText) &&
+        hasThreadMetadata(botRead, rootId),
+      "bot_read_thread_followup",
+    );
+    logSafe("bot_read_thread_followup", { bot_read_found: true, thread_metadata: true });
+
+    const reply = await liveStep("bot_thread_followup_reply", () =>
+      sendMessage({
+        client: params.botClient,
+        chatId: params.env.chatId,
+        text: followupReplyText,
+        convertMarkdown: false,
+        replyToId: String(followup.id),
+        threadId: botRead.threadId ?? rootId,
+      }),
+    );
+    assertLive(!!reply?.postId, "bot_thread_followup_reply");
+    params.createdBotPostIds.push(reply!.postId);
+    logSafe("bot_thread_followup_reply", { sent: true });
+
+    const ownerReadReply = await liveStep("owner_read_thread_followup_reply", () =>
+      waitForPost(params.ownerClient, params.env.chatId, followupReplyText, params.env.recordCount),
+    );
+    assertLive(
+      ownerReadReply?.id === reply?.postId &&
+        !!ownerReadReply?.text?.includes(followupReplyText) &&
+        hasThreadMetadata(ownerReadReply, rootId),
+      "owner_read_thread_followup_reply",
+    );
+    logSafe("owner_read_thread_followup_reply", {
+      owner_read_found: true,
+      thread_metadata: true,
+    });
+  } finally {
+    await wsWaiter.stop();
+  }
+}
+
 async function runCalendarEventScenario(params: {
   env: LiveEnv;
   ownerClient: RingCentralClient;
@@ -658,6 +782,7 @@ function readLiveEnv(): LiveEnv {
     cleanup: readBooleanEnv("RC_E2E_CLEANUP", false),
     wsTimeoutMs: readPositiveIntegerEnv("RC_E2E_WS_TIMEOUT_MS", 30_000, 5_000, 120_000),
     fileUpload: readBooleanEnv("RC_E2E_FILE_UPLOAD", true),
+    threadFollowup: readBooleanEnv("RC_E2E_THREAD_FOLLOWUP", false),
   };
   if (missing.length > 0) {
     throw new Error(`Missing RingCentral live smoke variables: ${missing.join(", ")}`);


### PR DESCRIPTION
## Summary

Add an optional RingCentral live smoke scenario for real threaded follow-up behavior.

The existing non-live integration test from #180 covers plugin tracker logic. This PR adds a gated live check for RingCentral's real API/WS event shape:

- owner sends a root message;
- bot sends a threaded reply to that root;
- owner sends a follow-up in the same thread without mentioning the bot;
- bot WebSocket receives the follow-up;
- bot REST history can read the follow-up;
- bot sends a threaded follow-up reply;
- owner REST history can read the bot follow-up reply.

## Behavior

The new scenario is disabled by default and only runs when:

```bash
RC_E2E_THREAD_FOLLOWUP=true
```

GitHub Actions also gets a manual `workflow_dispatch` input:

- `thread_followup`, default `false`

PR/push live smoke remains unchanged by default to avoid making RingCentral thread UI/API timing a hard gate for every run.

## Safe Logging / Summary

Adds Step Summary / safe log stages:

- `thread_root_send`
- `bot_thread_root_reply`
- `owner_thread_followup_send`
- `bot_ws_thread_followup_receive`
- `bot_read_thread_followup`
- `bot_thread_followup_reply`
- `owner_read_thread_followup_reply`

Logs and summary continue to avoid chat id, post id, message text, token, JWT, and client secret. Only boolean status, duration, and safe metadata are emitted.

## Test Plan

- `pnpm typecheck`
- `pnpm vitest run src/live/ringcentral-live.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm pack:check`
- `git diff --check`

Optional manual live validation:

```bash
source ~/.secrets.env
RC_E2E_ENABLED=true \
RC_E2E_REQUIRED=true \
RC_E2E_THREAD_FOLLOWUP=true \
RC_E2E_CLEANUP=true \
pnpm test:live:ringcentral
```
