### PR TITLE
Refactor RingCentral DM and group surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ manual development outside the OpenClaw plugin manager.
 ## Features
 
 - Bot Add-in WebSocket ingress and outbound replies
-- Optional owner JWT credentials for owner-observed groups, history reads, and fallback sends
-- OpenClaw channel ingress policy for DM/group allowlists, pairing, mention gates, and ignored/allowed channels
+- Optional owner JWT credentials for owner-observed chats, history reads, and fallback sends
+- OpenClaw channel ingress policy for DM pairing/allowlists, Team allowlists, group DM allowlists, and mention gates
 - Threaded replies with `off`, `first`, and `all` modes
 - Thread follow-up detection: once the bot participates in a thread, subsequent messages in that thread can skip the mention requirement (controlled by `threadRequireMention`)
 - Inbound file/image attachments are downloaded into OpenClaw managed media storage after admission
@@ -74,7 +74,7 @@ Owner credentials for history/fallback:
 
 `credentials` is still accepted as a deprecated alias for `ownerCredentials`.
 
-Group allowlist with per-group mention gate and thread follow-up:
+Team allowlist with per-team mention gate and thread follow-up:
 
 ```json
 {
@@ -83,11 +83,13 @@ Group allowlist with per-group mention gate and thread follow-up:
       "enabled": true,
       "botToken": "your-bot-static-token",
       "groupPolicy": "allowlist",
-      "requireMention": true,
       "threadRequireMention": false,
-      "groups": {
+      "teams": {
+        "*": {
+          "requireMention": true
+        },
         "123456789": {
-          "enabled": true,
+          "allow": true,
           "requireMention": true,
           "users": ["sender-id-1", "sender-id-2"]
         }
@@ -97,9 +99,34 @@ Group allowlist with per-group mention gate and thread follow-up:
 }
 ```
 
+`Team` and `Everyone` chats are treated as channel surfaces. `teams."*"` is only
+for defaults such as `requireMention`; it does not allowlist every team.
+
 When `threadRequireMention` is `false`, replies inside a thread the bot has
 already participated in do not need a new mention to activate the bot.
 Default is `true` (every message in a thread needs a mention).
+
+RingCentral `Group` conversations are treated like Discord group DMs and are
+ignored by default. Enable only explicit group DM conversations:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "dm": {
+        "groupEnabled": true,
+        "groupChannels": {
+          "987654321": {
+            "allow": true,
+            "requireMention": false,
+            "users": ["sender-id-1"]
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 Opt in to the processing placeholder (shown while an agent run is active):
 
@@ -124,17 +151,51 @@ DM policy and sender allowlist:
 {
   "channels": {
     "ringcentral": {
-      "dm": {
-        "policy": "allowlist",
-        "allowFrom": ["sender-id-1"]
-      }
+      "dmPolicy": "allowlist",
+      "allowFrom": ["sender-id-1"]
     }
   }
 }
 ```
 
-`dm.policy` can be `disabled` (default for group-only deployments), `allowlist`,
-`pairing`, or `open`.
+`dmPolicy` can be `disabled`, `allowlist`, `pairing`, or `open`. The default is
+`pairing`. `dmPolicy: "open"` requires `allowFrom: ["*"]`.
+
+`allowFrom` matches stable RingCentral person IDs by default. Email matching is
+disabled unless `dangerouslyAllowEmailMatching: true` is set.
+
+## Targets
+
+Canonical outbound targets are provider-neutral and use the selected
+`ringcentral` channel to determine transport:
+
+| Target | Description |
+| --- | --- |
+| `user:<personId>` | Create/find a DM with that RingCentral person, then send |
+| `team:<chatId>` | Send to a RingCentral Team chat |
+| `channel:<chatId>` | Send to an Everyone/channel chat |
+| `group:<chatId>` | Send to an explicitly configured RingCentral Group conversation |
+
+Legacy `ringcentral:*`, `rc:*`, and bare numeric targets are rejected.
+
+## Breaking Migration
+
+This release intentionally removes the old access-control shape:
+
+| Old | New |
+| --- | --- |
+| `allowedUserEmails` | `allowFrom` with stable person IDs |
+| `allowAllUsers` | `dmPolicy: "open"` plus `allowFrom: ["*"]` |
+| `allowedChannels` | `teams` |
+| `ignoredChannels` | omit or set `teams.<id>.allow=false` |
+| `freeResponseChannels` | `teams.<id>.requireMention=false` |
+| `groups` | `teams` |
+| `dm.policy` | `dmPolicy` |
+| `dm.allowFrom` | `allowFrom` |
+
+The corresponding legacy env vars (`RC_ALLOWED_USER_EMAILS`,
+`RC_ALLOW_ALL_USERS`, `RC_ALLOWED_CHANNELS`, `RC_IGNORED_CHANNELS`, and
+`RC_FREE_RESPONSE_CHANNELS`) are rejected with migration errors.
 
 ## Pair With A Dedicated Agent
 
@@ -186,13 +247,15 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 | `RC_USER_CLIENT_ID` | Owner REST API app client ID |
 | `RC_USER_CLIENT_SECRET` | Owner REST API app client secret |
 | `RC_USER_JWT_TOKEN` | Owner JWT token |
-| `RC_ALLOWED_USER_EMAILS` | Comma-separated DM/user allowlist aliases |
-| `RC_ALLOW_ALL_USERS` | Allow all DM senders |
-| `RC_ALLOWED_CHANNELS` | Comma-separated chat IDs allowed for group/channel ingress |
-| `RC_IGNORED_CHANNELS` | Comma-separated chat IDs ignored for ingress |
-| `RC_REQUIRE_MENTION` | Require mention in groups, default `true` |
+| `RC_DM_POLICY` | `disabled`, `allowlist`, `pairing`, or `open`; default `pairing` |
+| `RC_ALLOW_FROM` | Comma-separated stable person IDs allowed for DMs |
+| `RC_GROUP_POLICY` | Team policy: `disabled`, `allowlist`, or `open`; default `disabled` |
+| `RC_TEAMS` | JSON object of Team configurations keyed by chat ID |
+| `RC_TEAM_REQUIRE_MENTION` | Wildcard Team mention default |
+| `RC_GROUP_DM_ENABLED` | Enable explicitly configured RingCentral Group conversations |
+| `RC_GROUP_DM_CHANNELS` | JSON object of Group DM configurations keyed by chat ID |
+| `RC_REQUIRE_MENTION` | Global Team mention override |
 | `RC_THREAD_REQUIRE_MENTION` | Require mention in thread follow-ups, default `true` |
-| `RC_FREE_RESPONSE_CHANNELS` | Channels that do not require mentions |
 | `RC_NO_THREAD_CHANNELS` | Channels where replies must be unthreaded |
 | `RC_REPLY_TO_MODE` | `off`, `first`, or `all`; default `first` |
 | `RC_PROCESSING_EMOJI_ENABLED` | Enable processing placeholder, default `false` |
@@ -209,18 +272,22 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `groupPolicy` | `disabled` | `disabled`, `allowlist`, or `open` |
-| `requireMention` | `true` | Require mention in group messages |
+| `dmPolicy` | `pairing` | `disabled`, `allowlist`, `pairing`, or `open` |
+| `allowFrom` | `[]` | Stable person IDs allowed in DMs |
+| `dangerouslyAllowEmailMatching` | `false` | Allow matching `allowFrom` against email aliases |
+| `groupPolicy` | `disabled` | Team/Everyone handling: `disabled`, `allowlist`, or `open` |
+| `requireMention` | `true` | Global Team mention override |
 | `threadRequireMention` | `true` | Require mention in thread follow-ups (set `false` to allow follow-up replies without mention) |
-| `groups.<chatId>.enabled` | `true` | Enable an allowlisted group |
-| `groups.<chatId>.requireMention` | inherited | Per-group mention gate |
-| `groups.<chatId>.users` | `[]` | Per-group sender allowlist |
-| `groups.<chatId>.systemPrompt` | — | Per-group system prompt override |
-| `dm.policy` | contextual | Bot-only defaults to `open`; owner credentials default to owner-only `allowlist` unless explicitly configured |
-| `dm.allowFrom` | `[]` | Stable sender IDs allowed in DMs |
+| `teams.<chatId>.allow` | `true` | Enable an allowlisted Team |
+| `teams.<chatId>.requireMention` | inherited | Per-Team mention gate |
+| `teams.<chatId>.users` | `[]` | Per-Team sender allowlist |
+| `teams.<chatId>.systemPrompt` | — | Per-Team system prompt override |
+| `dm.groupEnabled` | `false` | Enable explicitly configured RingCentral Group conversations |
+| `dm.groupChannels.<chatId>.allow` | `true` | Enable an allowlisted group DM |
+| `dm.groupChannels.<chatId>.requireMention` | `false` | Per-group-DM mention gate |
+| `dm.groupChannels.<chatId>.users` | `[]` | Per-group-DM sender allowlist |
 | `replyToMode` | `first` | Threading behavior for replies (`off`, `first`, `all`) |
 | `noThreadChannels` | `[]` | Chat IDs that force unthreaded sends |
-| `freeResponseChannels` | `[]` | Chat IDs that do not require mentions |
 | `processingPlaceholder.enabled` | `false` | Show emoji placeholder while agent is processing |
 | `processingPlaceholder.initialText` | `👀` | Initial placeholder text |
 | `processingPlaceholder.delayedText` | `⏳` | Text shown after edit delay |
@@ -234,8 +301,6 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 | `textChunkLimit` | — | Max text length per message before chunking |
 | `historyMessageLimit` | `250` | Default history record count (max `1000`) |
 | `homeChannel` | — | Default history/home chat ID |
-
-When owner credentials are configured and no explicit DM allowlist is provided, the effective default is owner-only unless `allowAllUsers` is enabled.
 
 ## RingCentral Setup
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -113,26 +113,6 @@
       "placeholder": "https://platform.ringcentral.com",
       "advanced": true
     },
-    "allowedUserEmails": {
-      "label": "Allowed User Emails",
-      "advanced": true
-    },
-    "allowAllUsers": {
-      "label": "Allow All Users",
-      "advanced": true
-    },
-    "allowedChannels": {
-      "label": "Allowed Channels",
-      "advanced": true
-    },
-    "ignoredChannels": {
-      "label": "Ignored Channels",
-      "advanced": true
-    },
-    "freeResponseChannels": {
-      "label": "Free-response Channels",
-      "advanced": true
-    },
     "threadRequireMention": {
       "label": "Require Mention in Threads",
       "advanced": true
@@ -189,43 +169,16 @@
       "placeholder": "123456789"
     },
     "groupPolicy": {
-      "label": "Group Policy",
-      "help": "How to handle group messages: disabled, allowlist, or open. When open, plain group messages are accepted unless requireMention or groups.<chat-id>.requireMention is true."
-    },
-    "groups": {
-      "label": "Allowed Groups",
-      "help": "Group/Team configurations keyed by Chat ID."
-    },
-    "groups.*": {
-      "label": "Group Configuration"
-    },
-    "groups.*.enabled": {
-      "label": "Enabled"
-    },
-    "groups.*.requireMention": {
-      "label": "Require @Mention"
-    },
-    "groups.*.systemPrompt": {
-      "label": "System Prompt",
-      "placeholder": "Custom instructions for this group."
-    },
-    "groups.*.users": {
-      "label": "Allowed Users",
-      "placeholder": "User ID or email"
+      "label": "Team Policy",
+      "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Team messages are mention-gated by default."
     },
     "requireMention": {
       "label": "Require @Mention (Global)",
-      "help": "Default @mention requirement for groups. If unset, groupPolicy=open accepts plain group messages; set true to require @mentions by default."
+      "help": "Default @mention requirement for Team/Everyone chats. Team messages are mention-gated by default when unset."
     },
     "dm": {
       "label": "DM Settings",
       "advanced": true
-    },
-    "dm.policy": {
-      "label": "DM Policy"
-    },
-    "dm.allowFrom": {
-      "label": "DM Allowlist"
     },
     "textChunkLimit": {
       "label": "Text Chunk Limit",
@@ -256,6 +209,67 @@
     },
     "actions.adaptiveCards": {
       "label": "Adaptive Cards"
+    },
+    "dmPolicy": {
+      "label": "DM Policy",
+      "help": "Controls direct message access: pairing, allowlist, open, or disabled. Open requires allowFrom to include \"*\"."
+    },
+    "allowFrom": {
+      "label": "DM Allowlist",
+      "help": "Stable RingCentral person IDs allowed in DMs. Email matching is disabled unless dangerouslyAllowEmailMatching is enabled."
+    },
+    "dangerouslyAllowEmailMatching": {
+      "label": "Allow Email Matching",
+      "help": "Dangerous compatibility mode for matching allowFrom entries against sender email aliases.",
+      "advanced": true
+    },
+    "teams": {
+      "label": "Allowed Teams",
+      "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults."
+    },
+    "teams.*": {
+      "label": "Team Configuration"
+    },
+    "teams.*.allow": {
+      "label": "Allow Team"
+    },
+    "teams.*.requireMention": {
+      "label": "Require @Mention"
+    },
+    "teams.*.systemPrompt": {
+      "label": "System Prompt",
+      "placeholder": "Custom instructions for this team."
+    },
+    "teams.*.users": {
+      "label": "Allowed Users",
+      "placeholder": "Stable RingCentral person ID"
+    },
+    "dm.groupEnabled": {
+      "label": "Enable Group DMs",
+      "help": "Allow explicitly configured RingCentral Group conversations.",
+      "advanced": true
+    },
+    "dm.groupChannels": {
+      "label": "Allowed Group DMs",
+      "help": "RingCentral Group conversation configurations keyed by chat ID.",
+      "advanced": true
+    },
+    "dm.groupChannels.*": {
+      "label": "Group DM Configuration"
+    },
+    "dm.groupChannels.*.allow": {
+      "label": "Allow Group DM"
+    },
+    "dm.groupChannels.*.requireMention": {
+      "label": "Require @Mention"
+    },
+    "dm.groupChannels.*.systemPrompt": {
+      "label": "System Prompt",
+      "placeholder": "Custom instructions for this group DM."
+    },
+    "dm.groupChannels.*.users": {
+      "label": "Allowed Users",
+      "placeholder": "Stable RingCentral person ID"
     }
   },
   "configSchema": {
@@ -311,33 +325,6 @@
       },
       "selfOnly": {
         "type": "boolean"
-      },
-      "allowedUserEmails": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "allowAllUsers": {
-        "type": "boolean"
-      },
-      "allowedChannels": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "ignoredChannels": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "freeResponseChannels": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
       },
       "threadRequireMention": {
         "type": "boolean"
@@ -417,59 +404,8 @@
           "open"
         ]
       },
-      "groups": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "requireMention": {
-              "type": "boolean"
-            },
-            "systemPrompt": {
-              "type": "string"
-            },
-            "users": {
-              "type": "array",
-              "items": {
-                "type": [
-                  "string",
-                  "number"
-                ]
-              }
-            }
-          }
-        }
-      },
       "requireMention": {
         "type": "boolean"
-      },
-      "dm": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "policy": {
-            "type": "string",
-            "enum": [
-              "disabled",
-              "allowlist",
-              "pairing",
-              "open"
-            ]
-          },
-          "allowFrom": {
-            "type": "array",
-            "items": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
-          }
-        }
       },
       "textChunkLimit": {
         "type": "integer",
@@ -502,6 +438,90 @@
           },
           "adaptiveCards": {
             "type": "boolean"
+          }
+        }
+      },
+      "dmPolicy": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "allowlist",
+          "pairing",
+          "open"
+        ]
+      },
+      "allowFrom": {
+        "type": "array",
+        "items": {
+          "type": [
+            "string",
+            "number"
+          ]
+        }
+      },
+      "dangerouslyAllowEmailMatching": {
+        "type": "boolean"
+      },
+      "teams": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow": {
+              "type": "boolean"
+            },
+            "requireMention": {
+              "type": "boolean"
+            },
+            "systemPrompt": {
+              "type": "string"
+            },
+            "users": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "number"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "dm": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "groupEnabled": {
+            "type": "boolean"
+          },
+          "groupChannels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "boolean"
+                },
+                "requireMention": {
+                  "type": "boolean"
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -578,33 +598,6 @@
           },
           "selfOnly": {
             "type": "boolean"
-          },
-          "allowedUserEmails": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "allowAllUsers": {
-            "type": "boolean"
-          },
-          "allowedChannels": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "ignoredChannels": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "freeResponseChannels": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "threadRequireMention": {
             "type": "boolean"
@@ -684,59 +677,8 @@
               "open"
             ]
           },
-          "groups": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "requireMention": {
-                  "type": "boolean"
-                },
-                "systemPrompt": {
-                  "type": "string"
-                },
-                "users": {
-                  "type": "array",
-                  "items": {
-                    "type": [
-                      "string",
-                      "number"
-                    ]
-                  }
-                }
-              }
-            }
-          },
           "requireMention": {
             "type": "boolean"
-          },
-          "dm": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "policy": {
-                "type": "string",
-                "enum": [
-                  "disabled",
-                  "allowlist",
-                  "pairing",
-                  "open"
-                ]
-              },
-              "allowFrom": {
-                "type": "array",
-                "items": {
-                  "type": [
-                    "string",
-                    "number"
-                  ]
-                }
-              }
-            }
           },
           "textChunkLimit": {
             "type": "integer",
@@ -769,6 +711,90 @@
               },
               "adaptiveCards": {
                 "type": "boolean"
+              }
+            }
+          },
+          "dmPolicy": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "allowlist",
+              "pairing",
+              "open"
+            ]
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "type": [
+                "string",
+                "number"
+              ]
+            }
+          },
+          "dangerouslyAllowEmailMatching": {
+            "type": "boolean"
+          },
+          "teams": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "boolean"
+                },
+                "requireMention": {
+                  "type": "boolean"
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "dm": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupEnabled": {
+                "type": "boolean"
+              },
+              "groupChannels": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "allow": {
+                      "type": "boolean"
+                    },
+                    "requireMention": {
+                      "type": "boolean"
+                    },
+                    "systemPrompt": {
+                      "type": "string"
+                    },
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": [
+                          "string",
+                          "number"
+                        ]
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -806,26 +832,6 @@
         "server": {
           "label": "API Server",
           "placeholder": "https://platform.ringcentral.com",
-          "advanced": true
-        },
-        "allowedUserEmails": {
-          "label": "Allowed User Emails",
-          "advanced": true
-        },
-        "allowAllUsers": {
-          "label": "Allow All Users",
-          "advanced": true
-        },
-        "allowedChannels": {
-          "label": "Allowed Channels",
-          "advanced": true
-        },
-        "ignoredChannels": {
-          "label": "Ignored Channels",
-          "advanced": true
-        },
-        "freeResponseChannels": {
-          "label": "Free-response Channels",
           "advanced": true
         },
         "threadRequireMention": {
@@ -884,43 +890,16 @@
           "placeholder": "123456789"
         },
         "groupPolicy": {
-          "label": "Group Policy",
-          "help": "How to handle group messages: disabled, allowlist, or open. When open, plain group messages are accepted unless requireMention or groups.<chat-id>.requireMention is true."
-        },
-        "groups": {
-          "label": "Allowed Groups",
-          "help": "Group/Team configurations keyed by Chat ID."
-        },
-        "groups.*": {
-          "label": "Group Configuration"
-        },
-        "groups.*.enabled": {
-          "label": "Enabled"
-        },
-        "groups.*.requireMention": {
-          "label": "Require @Mention"
-        },
-        "groups.*.systemPrompt": {
-          "label": "System Prompt",
-          "placeholder": "Custom instructions for this group."
-        },
-        "groups.*.users": {
-          "label": "Allowed Users",
-          "placeholder": "User ID or email"
+          "label": "Team Policy",
+          "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Team messages are mention-gated by default."
         },
         "requireMention": {
           "label": "Require @Mention (Global)",
-          "help": "Default @mention requirement for groups. If unset, groupPolicy=open accepts plain group messages; set true to require @mentions by default."
+          "help": "Default @mention requirement for Team/Everyone chats. Team messages are mention-gated by default when unset."
         },
         "dm": {
           "label": "DM Settings",
           "advanced": true
-        },
-        "dm.policy": {
-          "label": "DM Policy"
-        },
-        "dm.allowFrom": {
-          "label": "DM Allowlist"
         },
         "textChunkLimit": {
           "label": "Text Chunk Limit",
@@ -951,6 +930,67 @@
         },
         "actions.adaptiveCards": {
           "label": "Adaptive Cards"
+        },
+        "dmPolicy": {
+          "label": "DM Policy",
+          "help": "Controls direct message access: pairing, allowlist, open, or disabled. Open requires allowFrom to include \"*\"."
+        },
+        "allowFrom": {
+          "label": "DM Allowlist",
+          "help": "Stable RingCentral person IDs allowed in DMs. Email matching is disabled unless dangerouslyAllowEmailMatching is enabled."
+        },
+        "dangerouslyAllowEmailMatching": {
+          "label": "Allow Email Matching",
+          "help": "Dangerous compatibility mode for matching allowFrom entries against sender email aliases.",
+          "advanced": true
+        },
+        "teams": {
+          "label": "Allowed Teams",
+          "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults."
+        },
+        "teams.*": {
+          "label": "Team Configuration"
+        },
+        "teams.*.allow": {
+          "label": "Allow Team"
+        },
+        "teams.*.requireMention": {
+          "label": "Require @Mention"
+        },
+        "teams.*.systemPrompt": {
+          "label": "System Prompt",
+          "placeholder": "Custom instructions for this team."
+        },
+        "teams.*.users": {
+          "label": "Allowed Users",
+          "placeholder": "Stable RingCentral person ID"
+        },
+        "dm.groupEnabled": {
+          "label": "Enable Group DMs",
+          "help": "Allow explicitly configured RingCentral Group conversations.",
+          "advanced": true
+        },
+        "dm.groupChannels": {
+          "label": "Allowed Group DMs",
+          "help": "RingCentral Group conversation configurations keyed by chat ID.",
+          "advanced": true
+        },
+        "dm.groupChannels.*": {
+          "label": "Group DM Configuration"
+        },
+        "dm.groupChannels.*.allow": {
+          "label": "Allow Group DM"
+        },
+        "dm.groupChannels.*.requireMention": {
+          "label": "Require @Mention"
+        },
+        "dm.groupChannels.*.systemPrompt": {
+          "label": "System Prompt",
+          "placeholder": "Custom instructions for this group DM."
+        },
+        "dm.groupChannels.*.users": {
+          "label": "Allowed Users",
+          "placeholder": "Stable RingCentral person ID"
         }
       }
     }

--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -16,12 +16,16 @@ describe("resolveAccount", () => {
     process.env = { ...origEnv };
   });
 
-  it("resolves bot config with Hermes defaults", () => {
+  it("resolves bot config with RingCentral defaults", () => {
     const account = resolveAccount({ botToken: "bot-token-123" });
     expect(account.botToken).toBe("bot-token-123");
     expect(account.server).toBe("https://platform.ringcentral.com");
     expect(account.replyToMode).toBe("first");
     expect(account.groupPolicy).toBe("disabled");
+    expect(account.dmPolicy).toBe("pairing");
+    expect(account.allowFrom).toEqual([]);
+    expect(account.groupDmEnabled).toBe(false);
+    expect(account.groupDmChannels).toEqual({});
     expect(account.requireMention).toBe(true);
     expect(account.requireMentionExplicit).toBe(false);
     expect(account.attachments).toEqual({
@@ -34,21 +38,51 @@ describe("resolveAccount", () => {
     expect(account.ownerCredentials).toBeUndefined();
   });
 
-  it("resolves from RC_* env", () => {
+  it("resolves from new RC_* env", () => {
     process.env.RC_BOT_TOKEN = "env-bot-token";
     process.env.RC_SERVER_URL = "https://sandbox.example.com";
-    process.env.RC_ALLOWED_USER_EMAILS = "Owner@Example.com, teammate@example.com";
+    process.env.RC_ALLOW_FROM = "u1,u2";
+    process.env.RC_DM_POLICY = "allowlist";
+    process.env.RC_GROUP_POLICY = "allowlist";
+    process.env.RC_TEAMS = JSON.stringify({ t1: { allow: true } });
+    process.env.RC_GROUP_DM_ENABLED = "true";
+    process.env.RC_GROUP_DM_CHANNELS = JSON.stringify({ g1: { allow: true, users: ["u1"] } });
     process.env.RC_REPLY_TO_MODE = "all";
     process.env.RC_REQUIRE_MENTION = "false";
     process.env.RC_DEBUG_INBOUND_MESSAGES = "true";
+
     const account = resolveAccount({});
+
     expect(account.botToken).toBe("env-bot-token");
     expect(account.server).toBe("https://sandbox.example.com");
-    expect(account.allowedUserEmails).toEqual(["owner@example.com", "teammate@example.com"]);
+    expect(account.allowFrom).toEqual(["u1", "u2"]);
+    expect(account.dmPolicy).toBe("allowlist");
+    expect(account.groupPolicy).toBe("allowlist");
+    expect(account.config.teams).toEqual({ t1: { allow: true } });
+    expect(account.groupDmEnabled).toBe(true);
+    expect(account.groupDmChannels).toEqual({ g1: { allow: true, users: ["u1"] } });
     expect(account.replyToMode).toBe("all");
     expect(account.requireMention).toBe(false);
     expect(account.requireMentionExplicit).toBe(true);
     expect(account.debugInboundMessages).toBe(true);
+  });
+
+  it("applies RC_TEAM_REQUIRE_MENTION to wildcard team defaults", () => {
+    const account = resolveAccount(
+      { botToken: "bot", teams: { t1: { allow: true } } },
+      { RC_TEAM_REQUIRE_MENTION: "false" },
+    );
+    expect(account.config.teams).toEqual({
+      t1: { allow: true },
+      "*": { requireMention: false },
+    });
+  });
+
+  it("requires wildcard allowFrom for public DMs", () => {
+    expect(() => resolveAccount({ botToken: "bot", dmPolicy: "open" })).toThrow(
+      'dmPolicy="open" requires allowFrom',
+    );
+    expect(resolveAccount({ botToken: "bot", dmPolicy: "open", allowFrom: ["*"] }).dmPolicy).toBe("open");
   });
 
   it("keeps processing placeholder opt-in via config or RC_* env", () => {
@@ -73,7 +107,25 @@ describe("resolveAccount", () => {
     expect(isAccountConfigured({})).toBe(false);
   });
 
-  it("resolves ownerCredentials and deprecated config alias", () => {
+  it("rejects legacy config fields", () => {
+    expect(() => resolveAccount({ botToken: "bot", allowedUserEmails: ["owner@example.com"] } as any)).toThrow(
+      "allowedUserEmails",
+    );
+    expect(() => resolveAccount({ botToken: "bot", groups: { g1: { enabled: true } } } as any)).toThrow(
+      "groups",
+    );
+    expect(() => resolveAccount({ botToken: "bot", dm: { policy: "open" } } as any)).toThrow(
+      "dm.policy",
+    );
+  });
+
+  it("rejects legacy RC_* env fields", () => {
+    process.env.RC_BOT_TOKEN = "bot";
+    process.env.RC_ALLOWED_USER_EMAILS = "owner@example.com";
+    expect(() => resolveAccount({})).toThrow("RC_ALLOWED_USER_EMAILS");
+  });
+
+  it("resolves ownerCredentials and deprecated credentials alias", () => {
     const primary = resolveAccount({
       botToken: "bot",
       ownerCredentials: { clientId: "id", clientSecret: "secret", jwt: "jwt" },
@@ -85,18 +137,6 @@ describe("resolveAccount", () => {
       credentials: { clientId: "id2", clientSecret: "secret2", jwt: "jwt2" },
     });
     expect(alias.ownerCredentials).toEqual({ clientId: "id2", clientSecret: "secret2", jwt: "jwt2" });
-  });
-
-  it("uses owner-only effective DM default when owner credentials are configured", () => {
-    const account = resolveAccount({
-      botToken: "bot",
-      ownerCredentials: { clientId: "id", clientSecret: "secret", jwt: "jwt" },
-    });
-    expect(account.dmPolicy).toBe("allowlist");
-  });
-
-  it("keeps bot-only DM default open", () => {
-    expect(resolveAccount({ botToken: "bot" }).dmPolicy).toBe("open");
   });
 
   it("resolves debug inbound message logging from config", () => {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -4,6 +4,10 @@ import type {
   ProcessingPlaceholderConfig,
   ResolvedAccount,
   ResolvedRingCentralOwnerCredentials,
+  RingCentralDmPolicy,
+  RingCentralGroupDmConfig,
+  RingCentralGroupPolicy,
+  RingCentralTeamConfig,
   RingCentralConfig,
   RingCentralOwnerCredentials,
   RingCentralReplyToMode,
@@ -22,6 +26,28 @@ const DEFAULT_PROCESSING_PLACEHOLDER: Required<ProcessingPlaceholderConfig> = {
   initialText: "👀",
   delayedText: "⏳",
   editDelaySeconds: 2,
+};
+
+const LEGACY_CONFIG_FIELDS: Record<string, string> = {
+  allowedUserEmails: "allowFrom",
+  allowAllUsers: 'dmPolicy: "open" with allowFrom: ["*"]',
+  allowedChannels: "teams",
+  ignoredChannels: "teams",
+  freeResponseChannels: "teams.*.requireMention=false",
+  groups: "teams",
+};
+
+const LEGACY_DM_FIELDS: Record<string, string> = {
+  policy: "dmPolicy",
+  allowFrom: "allowFrom",
+};
+
+const LEGACY_ENV_FIELDS: Record<string, string> = {
+  RC_ALLOWED_USER_EMAILS: "RC_ALLOW_FROM",
+  RC_ALLOW_ALL_USERS: 'RC_DM_POLICY=open and RC_ALLOW_FROM="*"',
+  RC_ALLOWED_CHANNELS: "RC_TEAMS",
+  RC_IGNORED_CHANNELS: "RC_TEAMS",
+  RC_FREE_RESPONSE_CHANNELS: "RC_TEAMS",
 };
 
 function readEnv(name: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -78,8 +104,91 @@ function readDelimitedEntries(
     .filter(Boolean);
 }
 
-function normalizeEmails(entries: string[]): string[] {
-  return Array.from(new Set(entries.map((entry) => entry.toLowerCase())));
+function normalizeAllowFrom(entries: Array<string | number> | string[]): string[] {
+  return Array.from(new Set(entries.map((entry) => String(entry).trim()).filter(Boolean)));
+}
+
+function readPolicy<T extends string>(
+  value: unknown,
+  envName: string,
+  env: NodeJS.ProcessEnv,
+  fallback: T,
+  allowed: readonly T[],
+): T {
+  const raw = String(value ?? readEnv(envName, env) ?? fallback).trim();
+  return (allowed as readonly string[]).includes(raw) ? (raw as T) : fallback;
+}
+
+function readRecordEnv<T extends Record<string, unknown>>(
+  envName: string,
+  env: NodeJS.ProcessEnv,
+): T | undefined {
+  const raw = readEnv(envName, env);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as T)
+      : undefined;
+  } catch {
+    throw new Error(`${envName} must be a JSON object.`);
+  }
+}
+
+function assertNoLegacyConfig(cfg: RingCentralConfig): void {
+  for (const [field, replacement] of Object.entries(LEGACY_CONFIG_FIELDS)) {
+    if (Object.prototype.hasOwnProperty.call(cfg, field)) {
+      throw new Error(
+        `Legacy RingCentral config field "${field}" is no longer supported. Use "${replacement}" instead.`,
+      );
+    }
+  }
+  const dm = cfg.dm as Record<string, unknown> | undefined;
+  if (dm) {
+    for (const [field, replacement] of Object.entries(LEGACY_DM_FIELDS)) {
+      if (Object.prototype.hasOwnProperty.call(dm, field)) {
+        throw new Error(
+          `Legacy RingCentral config field "dm.${field}" is no longer supported. Use "${replacement}" instead.`,
+        );
+      }
+    }
+  }
+}
+
+function assertNoLegacyEnv(env: NodeJS.ProcessEnv): void {
+  for (const [name, replacement] of Object.entries(LEGACY_ENV_FIELDS)) {
+    if (readEnv(name, env) !== undefined) {
+      throw new Error(`Legacy RingCentral env "${name}" is no longer supported. Use "${replacement}" instead.`);
+    }
+  }
+}
+
+function resolveTeams(
+  cfg: RingCentralConfig,
+  env: NodeJS.ProcessEnv,
+): Record<string, RingCentralTeamConfig> | undefined {
+  const envTeams = readRecordEnv<Record<string, RingCentralTeamConfig>>("RC_TEAMS", env);
+  const teams = cfg.teams ?? envTeams;
+  const teamRequireMention = readEnv("RC_TEAM_REQUIRE_MENTION", env);
+  if (teamRequireMention === undefined) {
+    return teams;
+  }
+  return {
+    ...(teams ?? {}),
+    "*": {
+      ...(teams?.["*"] ?? {}),
+      requireMention: readBoolean(undefined, true, "RC_TEAM_REQUIRE_MENTION", env),
+    },
+  };
+}
+
+function resolveGroupDmChannels(
+  cfg: RingCentralConfig,
+  env: NodeJS.ProcessEnv,
+): Record<string, RingCentralGroupDmConfig> {
+  return cfg.dm?.groupChannels ?? readRecordEnv<Record<string, RingCentralGroupDmConfig>>("RC_GROUP_DM_CHANNELS", env) ?? {};
 }
 
 function resolveOwnerCredentials(
@@ -158,21 +267,34 @@ export function resolveAccount(
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedAccount {
   const cfg = channelConfig ?? {};
+  assertNoLegacyConfig(cfg);
+  assertNoLegacyEnv(env);
   const botToken = cfg.botToken ?? readEnv("RC_BOT_TOKEN", env) ?? "";
   if (!botToken) {
     throw new Error("RingCentral bot token not configured. Set botToken in config or RC_BOT_TOKEN.");
   }
 
   const ownerCredentials = resolveOwnerCredentials(cfg, env);
-  const allowedUserEmails = normalizeEmails(
-    readDelimitedEntries(cfg.allowedUserEmails, "RC_ALLOWED_USER_EMAILS", env),
+  const allowFrom = normalizeAllowFrom(
+    cfg.allowFrom ?? readDelimitedEntries(undefined, "RC_ALLOW_FROM", env),
   );
-  const allowAllUsers = readBoolean(cfg.allowAllUsers, false, "RC_ALLOW_ALL_USERS", env);
-  const dmPolicy =
-    cfg.dm?.policy ??
-    (ownerCredentials && !allowAllUsers && allowedUserEmails.length === 0 && !cfg.dm?.allowFrom?.length
-      ? "allowlist"
-      : "open");
+  const dmPolicy = readPolicy<RingCentralDmPolicy>(
+    cfg.dmPolicy,
+    "RC_DM_POLICY",
+    env,
+    "pairing",
+    ["disabled", "allowlist", "pairing", "open"],
+  );
+  if (dmPolicy === "open" && !allowFrom.includes("*")) {
+    throw new Error('RingCentral dmPolicy="open" requires allowFrom to include "*".');
+  }
+  const groupPolicy = readPolicy<RingCentralGroupPolicy>(
+    cfg.groupPolicy,
+    "RC_GROUP_POLICY",
+    env,
+    "disabled",
+    ["disabled", "allowlist", "open"],
+  );
 
   const historyMessageLimit = clampInteger(
     readNumber(cfg.historyMessageLimit, DEFAULT_HISTORY_MESSAGE_LIMIT, "RC_HISTORY_MESSAGE_LIMIT", env),
@@ -187,17 +309,16 @@ export function resolveAccount(
     ownerCredentials,
     credentials: ownerCredentials,
     server: cfg.server ?? readEnv("RC_SERVER_URL", env) ?? DEFAULT_SERVER,
-    allowedUserEmails,
-    allowAllUsers,
-    allowedChannels: readDelimitedEntries(cfg.allowedChannels, "RC_ALLOWED_CHANNELS", env),
-    ignoredChannels: readDelimitedEntries(cfg.ignoredChannels, "RC_IGNORED_CHANNELS", env),
-    freeResponseChannels: readDelimitedEntries(cfg.freeResponseChannels, "RC_FREE_RESPONSE_CHANNELS", env),
+    allowFrom,
+    dangerouslyAllowEmailMatching: readBoolean(cfg.dangerouslyAllowEmailMatching, false, undefined, env),
+    groupDmEnabled: readBoolean(cfg.dm?.groupEnabled, false, "RC_GROUP_DM_ENABLED", env),
+    groupDmChannels: resolveGroupDmChannels(cfg, env),
     noThreadChannels: readDelimitedEntries(cfg.noThreadChannels, "RC_NO_THREAD_CHANNELS", env),
     replyToMode: resolveReplyToMode(cfg.replyToMode, env),
     requireMention,
     requireMentionExplicit: cfg.requireMention !== undefined || requireMentionEnv !== undefined,
     threadRequireMention: readBoolean(cfg.threadRequireMention, true, "RC_THREAD_REQUIRE_MENTION", env),
-    groupPolicy: cfg.groupPolicy ?? "disabled",
+    groupPolicy,
     dmPolicy,
     textChunkLimit: cfg.textChunkLimit,
     processingPlaceholder: resolveProcessingPlaceholder(cfg, env),
@@ -206,7 +327,7 @@ export function resolveAccount(
     historyMessageLimit,
     homeChannel: cfg.homeChannel ?? readEnv("RC_HOME_CHANNEL", env),
     homeChannelName: cfg.homeChannelName ?? readEnv("RC_HOME_CHANNEL_NAME", env),
-    config: cfg,
+    config: { ...cfg, teams: resolveTeams(cfg, env) },
   };
 }
 

--- a/src/actions-adapter.test.ts
+++ b/src/actions-adapter.test.ts
@@ -379,15 +379,15 @@ describe("ringCentralMessageActions", () => {
   });
 
   it("extracts send target for shared send action", () => {
-    expect(ringCentralMessageActions.extractToolSend?.({ args: { action: "send", to: "ringcentral:group:g1" } })).toEqual({
-      to: "ringcentral:group:g1",
+    expect(ringCentralMessageActions.extractToolSend?.({ args: { action: "send", to: "team:g1" } })).toEqual({
+      to: "team:g1",
     });
   });
 
   it("routes shared read action", async () => {
     await ringCentralMessageActions.handleAction?.({
       action: "read",
-      params: { to: "ringcentral:group:c1", count: 5 },
+      params: { to: "team:c1", count: 5 },
       cfg,
     } as any);
     expect(actions.actionReadMessages).toHaveBeenCalledWith(expect.anything(), "c1", 5);

--- a/src/actions-adapter.ts
+++ b/src/actions-adapter.ts
@@ -11,7 +11,7 @@ import type { CreateAdaptiveCardRequest } from "./types.js";
 import { createBotClient } from "./client.js";
 import { getRcConfig, isAccountConfigured, resolveAccount } from "./accounts.js";
 import * as actions from "./actions.js";
-import { extractChatId } from "./targets.js";
+import { parseTarget } from "./targets.js";
 
 const CHAT_SCOPED_ACTIONS = new Set<ActionName>([
   "send-message",
@@ -175,9 +175,28 @@ function agentToolResult(details: unknown): AgentToolResult<unknown> {
   };
 }
 
-function readTargetChatId(params: Record<string, unknown>): string {
-  const target = String(params.to ?? params.chatId ?? params.chat_id ?? "");
-  return extractChatId(target) ?? target;
+async function resolveTargetChatId(
+  client: RingCentralClient,
+  params: Record<string, unknown>,
+): Promise<string> {
+  const hasCanonicalTarget = params.to !== undefined || params.target !== undefined;
+  const target = String(params.to ?? params.target ?? params.chatId ?? params.chat_id ?? "");
+  if (!target) {
+    return "";
+  }
+  const parsed = parseTarget(target);
+  if (parsed?.kind === "user") {
+    return (await client.createOrFindDm([parsed.id])).id;
+  }
+  if (parsed) {
+    return parsed.id;
+  }
+  if (hasCanonicalTarget) {
+    throw new Error(
+      `Invalid RingCentral target "${target}". Use user:<personId>, team:<chatId>, group:<chatId>, or channel:<chatId>.`,
+    );
+  }
+  return target;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -236,7 +255,7 @@ export const ringCentralMessageActions: ChannelMessageActionAdapter = {
   handleAction: async (ctx) => {
     const client = createActionClient(ctx.cfg);
     const params = ctx.params as Record<string, unknown>;
-    const chatId = readTargetChatId(params);
+    const chatId = await resolveTargetChatId(client, params);
     const postId = String(params.postId ?? params.post_id ?? params.messageId ?? "");
     const text = String(params.text ?? params.message ?? "");
     switch (ctx.action) {
@@ -262,7 +281,7 @@ export async function handleAction(
   params: Record<string, unknown>,
   sessionChatId?: string,
 ): Promise<unknown> {
-  const chatId = String(params.chatId ?? params.chat_id ?? "");
+  const chatId = await resolveTargetChatId(client, params);
   const postId = String(params.postId ?? params.post_id ?? params.messageId ?? "");
   const text = String(params.text ?? params.message ?? "");
 
@@ -303,7 +322,7 @@ async function executeAction(
   action: ActionName,
   params: Record<string, unknown>,
 ): Promise<unknown> {
-  const chatId = String(params.chatId ?? params.chat_id ?? "");
+  const chatId = await resolveTargetChatId(client, params);
   const postId = String(params.postId ?? params.post_id ?? params.messageId ?? "");
   const text = String(params.text ?? params.message ?? "");
 

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ringcentralPlugin } from "./channel.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Map([["content-type", "application/json"]]),
+  };
+}
+
+function cfg() {
+  return {
+    channels: {
+      ringcentral: {
+        botToken: "bot-token",
+        server: "https://api.example.com",
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("ringcentralPlugin outbound targets", () => {
+  it("creates or finds a DM before sending to user targets", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-chat-1", type: "Direct" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "post-1" }));
+
+    const result = await ringcentralPlugin.outbound!.sendText!({
+      cfg: cfg(),
+      accountId: "default",
+      to: "user:u1",
+      text: "hello",
+    } as any);
+
+    expect(result).toMatchObject({ ok: true, messageId: "post-1" });
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/team-messaging/v1/conversations",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ members: [{ id: "u1" }] }),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.com/team-messaging/v1/chats/dm-chat-1/posts",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("sends directly to team targets", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "post-1" }));
+
+    const result = await ringcentralPlugin.outbound!.sendText!({
+      cfg: cfg(),
+      accountId: "default",
+      to: "team:t1",
+      text: "hello",
+    } as any);
+
+    expect(result).toMatchObject({ ok: true, messageId: "post-1" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/t1/posts",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects legacy provider-prefixed targets", async () => {
+    const result = await ringcentralPlugin.outbound!.sendText!({
+      cfg: cfg(),
+      accountId: "default",
+      to: "ringcentral:group:g1",
+      text: "hello",
+    } as any);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(String((result as any).error?.message)).toContain("Invalid RingCentral target");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -19,7 +19,7 @@ import { chunkText } from "./markdown.js";
 import { RingCentralWebSocketMonitor } from "./monitor.js";
 import { sendMessage } from "./send.js";
 import { DEFAULT_TEXT_CHUNK_LIMIT, RINGCENTRAL_CHANNEL_ID } from "./shared.js";
-import { extractChatId, normalizeTarget, parseTarget } from "./targets.js";
+import { normalizeTarget, parseTarget } from "./targets.js";
 import { resolveReplyTransport, ThreadParticipationTracker } from "./threading.js";
 import type { ResolvedAccount } from "./types.js";
 
@@ -78,7 +78,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
       configured: !!account.botToken,
       statusState: account.botToken ? "configured" : "not configured",
       dmPolicy: account.dmPolicy,
-      allowFrom: account.config.dm?.allowFrom?.map(String),
+      allowFrom: account.allowFrom,
       tokenSource: account.config.botToken ? "config" : "env:RC_BOT_TOKEN",
       credentialSource: hasOwnerCredentials(account) ? "owner credentials" : "none",
     }),
@@ -169,18 +169,20 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
     deliveryMode: "direct",
     textChunkLimit: DEFAULT_TEXT_CHUNK_LIMIT,
     sendText: async (outCtx: ChannelOutboundContext) => {
-      const chatId = extractChatId(outCtx.to);
-      if (!chatId) {
+      const account = resolveAccount(getRcConfig(outCtx.cfg));
+      const botClient = createBotClient(account.server, account.botToken);
+      const ownerClient = createOwnerClientFromAccount(account);
+      let chatId: string;
+      try {
+        chatId = await resolveOutboundChatId(outCtx.to, botClient, ownerClient);
+      } catch (err) {
         return {
           ok: false,
-          error: new Error(`Invalid target: ${outCtx.to}`),
+          error: err instanceof Error ? err : new Error(String(err)),
           channel: RINGCENTRAL_CHANNEL_ID,
           messageId: "",
         } as never;
       }
-      const account = resolveAccount(getRcConfig(outCtx.cfg));
-      const botClient = createBotClient(account.server, account.botToken);
-      const ownerClient = createOwnerClientFromAccount(account);
       const state = stateFor(outCtx.accountId ?? "default");
       let lastPostId = "";
       for (const chunk of chunkText(outCtx.text ?? "", account.textChunkLimit ?? DEFAULT_TEXT_CHUNK_LIMIT)) {
@@ -207,20 +209,24 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
       return { ok: true, channel: RINGCENTRAL_CHANNEL_ID, messageId: lastPostId } as never;
     },
     sendMedia: async (outCtx: ChannelOutboundContext) => {
-      const chatId = extractChatId(outCtx.to);
-      if (!chatId) {
+      const account = resolveAccount(getRcConfig(outCtx.cfg));
+      const botClient = createBotClient(account.server, account.botToken);
+      const ownerClient = createOwnerClientFromAccount(account);
+      let chatId: string;
+      try {
+        chatId = await resolveOutboundChatId(outCtx.to, botClient, ownerClient);
+      } catch (err) {
         return {
           ok: false,
-          error: new Error(`Invalid target: ${outCtx.to}`),
+          error: err instanceof Error ? err : new Error(String(err)),
           channel: RINGCENTRAL_CHANNEL_ID,
           messageId: "",
         } as never;
       }
-      const account = resolveAccount(getRcConfig(outCtx.cfg));
       const state = stateFor(outCtx.accountId ?? "default");
       const result = await sendMessage({
-        client: createBotClient(account.server, account.botToken),
-        fallbackClient: createOwnerClientFromAccount(account),
+        client: botClient,
+        fallbackClient: ownerClient,
         chatId,
         mediaUrl: outCtx.mediaUrl,
         replyToId: outCtx.replyToId,
@@ -266,20 +272,20 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
     normalizeTarget: (raw: string) => normalizeTarget(raw),
     inferTargetChatType: ({ to }) => {
       const parsed = parseTarget(to);
-      if (parsed?.kind === "dm" || parsed?.kind === "user") {
+      if (parsed?.kind === "user") {
         return "direct";
       }
-      if (parsed?.kind === "channel") {
+      if (parsed?.kind === "channel" || parsed?.kind === "team") {
         return "channel";
       }
-      if (parsed?.kind === "group" || parsed?.kind === "chat") {
+      if (parsed?.kind === "group") {
         return "group";
       }
       return undefined;
     },
     targetResolver: {
-      looksLikeId: (raw) => !!extractChatId(raw),
-      hint: "ringcentral:<dm|group|channel|chat>:<id>",
+      looksLikeId: (raw) => !!parseTarget(raw),
+      hint: "user:<personId>|team:<chatId>|group:<chatId>|channel:<chatId>",
     },
   },
 
@@ -301,9 +307,10 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
     },
     listGroups: async ({ cfg, limit }) => {
       const account = resolveAccount(getRcConfig(cfg));
-      return (account.allowedChannels.length ? account.allowedChannels : Object.keys(account.config.groups ?? {}))
+      return Object.keys(account.config.teams ?? {})
+        .filter((id) => id !== "*")
         .slice(0, limit ?? 50)
-        .map((id) => ({ kind: "group", id, name: id }));
+        .map((id) => ({ kind: "channel", id, name: id }));
     },
   },
 
@@ -328,7 +335,7 @@ export const ringcentralPlugin: ChannelPlugin<ResolvedAccount> = {
       connected: runtime?.connected,
       label: account.config.name ?? "RingCentral",
       dmPolicy: account.dmPolicy,
-      allowFrom: account.config.dm?.allowFrom?.map(String),
+      allowFrom: account.allowFrom,
       credentialSource: hasOwnerCredentials(account) ? "owner credentials" : "none",
     }) as never,
   },
@@ -358,6 +365,30 @@ function createOwnerClientFromAccount(account: ResolvedAccount): RingCentralClie
 
 function createPreferredReadClient(account: ResolvedAccount): RingCentralClient {
   return createOwnerClientFromAccount(account) ?? createBotClient(account.server, account.botToken);
+}
+
+async function resolveOutboundChatId(
+  target: string,
+  botClient: RingCentralClient,
+  ownerClient?: RingCentralClient,
+): Promise<string> {
+  const parsed = parseTarget(target);
+  if (!parsed) {
+    throw new Error(
+      `Invalid RingCentral target "${target}". Use user:<personId>, team:<chatId>, group:<chatId>, or channel:<chatId>.`,
+    );
+  }
+  if (parsed.kind !== "user") {
+    return parsed.id;
+  }
+  try {
+    return (await botClient.createOrFindDm([parsed.id])).id;
+  } catch (err) {
+    if (ownerClient) {
+      return (await ownerClient.createOrFindDm([parsed.id])).id;
+    }
+    throw err;
+  }
 }
 
 async function resolvePersonId(client: RingCentralClient): Promise<string | undefined> {

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ringCentralConfigSchema } from "./config-schema.js";
 
 describe("ringCentralConfigSchema", () => {
@@ -12,7 +12,7 @@ describe("ringCentralConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts full config", () => {
+  it("accepts full canonical config", () => {
     const result = ringCentralConfigSchema.safeParse({
       enabled: true,
       name: "My Bot",
@@ -22,11 +22,20 @@ describe("ringCentralConfigSchema", () => {
       server: "https://platform.ringcentral.com",
       botExtensionId: "12345",
       selfOnly: false,
-      allowedUserEmails: ["owner@example.com"],
-      allowAllUsers: false,
-      allowedChannels: ["g1"],
-      ignoredChannels: ["g2"],
-      freeResponseChannels: ["g3"],
+      dmPolicy: "allowlist",
+      allowFrom: ["u1", 99],
+      dangerouslyAllowEmailMatching: false,
+      groupPolicy: "allowlist",
+      teams: {
+        "*": { requireMention: true },
+        "123": { allow: true, requireMention: true, systemPrompt: "Be helpful", users: ["u1", 42] },
+      },
+      dm: {
+        groupEnabled: true,
+        groupChannels: {
+          "g1": { allow: true, requireMention: false, users: ["u1"] },
+        },
+      },
       threadRequireMention: true,
       noThreadChannels: ["g4"],
       replyToMode: "first",
@@ -40,12 +49,7 @@ describe("ringCentralConfigSchema", () => {
       historyMessageLimit: 250,
       homeChannel: "g-home",
       homeChannelName: "Home",
-      groupPolicy: "allowlist",
-      groups: {
-        "123": { enabled: true, requireMention: true, systemPrompt: "Be helpful", users: ["u1", 42] },
-      },
       requireMention: true,
-      dm: { policy: "open", allowFrom: ["u1", 99] },
       textChunkLimit: 2000,
       allowBots: false,
       workspace: "/tmp/workspace",
@@ -59,9 +63,22 @@ describe("ringCentralConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid dm.policy enum", () => {
-    const result = ringCentralConfigSchema.safeParse({ dm: { policy: "invalid" } });
+  it("rejects invalid dmPolicy enum", () => {
+    const result = ringCentralConfigSchema.safeParse({ dmPolicy: "invalid" });
     expect(result.success).toBe(false);
+  });
+
+  it("rejects dmPolicy open without wildcard allowFrom", () => {
+    const result = ringCentralConfigSchema.safeParse({ dmPolicy: "open", allowFrom: ["u1"] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects legacy access-control fields", () => {
+    expect(ringCentralConfigSchema.safeParse({ allowedUserEmails: ["owner@example.com"] }).success).toBe(false);
+    expect(ringCentralConfigSchema.safeParse({ allowedChannels: ["g1"] }).success).toBe(false);
+    expect(ringCentralConfigSchema.safeParse({ groups: { g1: { enabled: true } } }).success).toBe(false);
+    expect(ringCentralConfigSchema.safeParse({ dm: { policy: "open" } }).success).toBe(false);
+    expect(ringCentralConfigSchema.safeParse({ dm: { allowFrom: ["u1"] } }).success).toBe(false);
   });
 
   it("rejects invalid replyToMode and out-of-range history limit", () => {
@@ -84,9 +101,9 @@ describe("ringCentralConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("accepts valid group config with mixed user ID types", () => {
+  it("accepts valid team config with mixed user ID types", () => {
     const result = ringCentralConfigSchema.safeParse({
-      groups: { "g1": { users: ["string-id", 12345] } },
+      teams: { "g1": { users: ["string-id", 12345] } },
     });
     expect(result.success).toBe(true);
   });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,11 +1,15 @@
 import { z } from "zod/v4";
 
-const groupConfigSchema = z.object({
-  enabled: z.boolean().optional(),
+const allowFromEntrySchema = z.union([z.string(), z.number()]);
+
+const teamConfigSchema = z.object({
+  allow: z.boolean().optional(),
   requireMention: z.boolean().optional(),
   systemPrompt: z.string().optional(),
-  users: z.array(z.union([z.string(), z.number()])).optional(),
+  users: z.array(allowFromEntrySchema).optional(),
 });
+
+const groupDmConfigSchema = teamConfigSchema;
 
 const credentialsSchema = z.object({
   clientId: z.string().optional(),
@@ -28,10 +32,16 @@ const attachmentsSchema = z.object({
   maxBytes: z.number().int().min(1).max(100 * 1024 * 1024).optional(),
 });
 
-const dmSchema = z.object({
-  policy: z.enum(["disabled", "allowlist", "pairing", "open"]).optional(),
-  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-});
+const dmSchema = z
+  .object({
+    groupEnabled: z.boolean().optional(),
+    groupChannels: z.record(z.string(), groupDmConfigSchema).optional(),
+  })
+  .passthrough()
+  .superRefine((value, ctx) => {
+    rejectLegacyField(value, ctx, "policy", "dmPolicy");
+    rejectLegacyField(value, ctx, "allowFrom", "allowFrom");
+  });
 
 const actionsSchema = z.object({
   messages: z.boolean().optional(),
@@ -42,6 +52,30 @@ const actionsSchema = z.object({
   adaptiveCards: z.boolean().optional(),
 });
 
+const legacyTopLevelFields: Record<string, string> = {
+  allowedUserEmails: "allowFrom",
+  allowAllUsers: 'dmPolicy: "open" with allowFrom: ["*"]',
+  allowedChannels: "teams",
+  ignoredChannels: "teams",
+  freeResponseChannels: "teams.*.requireMention=false",
+  groups: "teams",
+};
+
+function rejectLegacyField(
+  value: Record<string, unknown>,
+  ctx: z.RefinementCtx,
+  field: string,
+  replacement: string,
+): void {
+  if (Object.prototype.hasOwnProperty.call(value, field)) {
+    ctx.addIssue({
+      code: "custom",
+      path: [field],
+      message: `Legacy RingCentral config field "${field}" is no longer supported. Use "${replacement}" instead.`,
+    });
+  }
+}
+
 export const ringCentralConfigSchema = z.object({
   enabled: z.boolean().optional(),
   name: z.string().optional(),
@@ -51,11 +85,12 @@ export const ringCentralConfigSchema = z.object({
   server: z.string().optional(),
   botExtensionId: z.string().optional(),
   selfOnly: z.boolean().optional(),
-  allowedUserEmails: stringListSchema,
-  allowAllUsers: z.boolean().optional(),
-  allowedChannels: stringListSchema,
-  ignoredChannels: stringListSchema,
-  freeResponseChannels: stringListSchema,
+  dmPolicy: z.enum(["disabled", "allowlist", "pairing", "open"]).optional(),
+  allowFrom: z.array(allowFromEntrySchema).optional(),
+  dangerouslyAllowEmailMatching: z.boolean().optional(),
+  groupPolicy: z.enum(["disabled", "allowlist", "open"]).optional(),
+  teams: z.record(z.string(), teamConfigSchema).optional(),
+  dm: dmSchema.optional(),
   threadRequireMention: z.boolean().optional(),
   noThreadChannels: stringListSchema,
   replyToMode: z.enum(["off", "first", "all"]).optional(),
@@ -65,12 +100,23 @@ export const ringCentralConfigSchema = z.object({
   historyMessageLimit: z.number().int().min(1).max(1000).optional(),
   homeChannel: z.string().optional(),
   homeChannelName: z.string().optional(),
-  groupPolicy: z.enum(["disabled", "allowlist", "open"]).optional(),
-  groups: z.record(z.string(), groupConfigSchema).optional(),
   requireMention: z.boolean().optional(),
-  dm: dmSchema.optional(),
   textChunkLimit: z.number().int().min(1).optional(),
   allowBots: z.boolean().optional(),
   workspace: z.string().optional(),
   actions: actionsSchema.optional(),
+}).passthrough().superRefine((value, ctx) => {
+  for (const [field, replacement] of Object.entries(legacyTopLevelFields)) {
+    rejectLegacyField(value, ctx, field, replacement);
+  }
+  if (value.dmPolicy === "open") {
+    const allowFrom = value.allowFrom ?? [];
+    if (!allowFrom.some((entry) => String(entry).trim() === "*")) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["allowFrom"],
+        message: 'RingCentral dmPolicy="open" requires allowFrom to include "*".',
+      });
+    }
+  }
 });

--- a/src/history-tool.test.ts
+++ b/src/history-tool.test.ts
@@ -33,7 +33,7 @@ describe("ringcentral_get_recent_messages", () => {
     const tool = createRingCentralHistoryTool({
       channels: { ringcentral: { botToken: "bot" } },
     });
-    const result = await tool.execute("call-1", { target: "ringcentral:group:g1" } as any);
+    const result = await tool.execute("call-1", { target: "team:g1" } as any);
     expect(result.content[0]?.text).toContain("owner credentials");
   });
 
@@ -65,7 +65,7 @@ describe("ringcentral_get_recent_messages", () => {
       );
 
     const result = await tool.execute("call-1", {
-      target: "ringcentral:group:g1",
+      target: "team:g1",
       record_count: 10,
     } as any);
 

--- a/src/history-tool.test.ts
+++ b/src/history-tool.test.ts
@@ -72,4 +72,27 @@ describe("ringcentral_get_recent_messages", () => {
     expect(result.content[0]?.text).toContain("hello");
     expect(result.details).toMatchObject({ chatId: "g1", count: 1 });
   });
+
+  it("does not resolve legacy ringcentral chat targets", async () => {
+    const tool = createRingCentralHistoryTool({
+      channels: {
+        ringcentral: {
+          botToken: "bot",
+          ownerCredentials: { clientId: "cid", clientSecret: "cs", jwt: "jwt" },
+        },
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ access_token: "access", expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ records: [] }));
+
+    const result = await tool.execute("call-1", {
+      target: "ringcentral:chat:g1",
+      target_type: "chat",
+      record_count: 10,
+    } as any);
+
+    expect(result.content[0]?.text).toContain("Unable to resolve RingCentral history target.");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/history-tool.ts
+++ b/src/history-tool.ts
@@ -114,7 +114,11 @@ async function resolveHistoryTarget(params: {
     return { chatId: mentioned.groups.id, label: target };
   }
   const parsed = parseTarget(target);
-  if (parsed && parsed.kind !== "dm" && parsed.kind !== "user") {
+  if (parsed?.kind === "user") {
+    const chat = await params.client.createOrFindDm([parsed.id]);
+    return { chatId: chat.id, label: parsed.id };
+  }
+  if (parsed) {
     return { chatId: parsed.id, label: target };
   }
   const chatId = extractChatId(target);

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -31,7 +31,7 @@ function makePost(overrides: Partial<Post> = {}): Post {
   };
 }
 
-function makeClient(chatType = "Group", email = "user@example.com") {
+function makeClient(chatType = "Team", email = "user@example.com") {
   return {
     getChat: vi.fn().mockResolvedValue({ id: "g1", type: chatType, name: "General" }),
     getPersonInfo: vi.fn().mockResolvedValue({ id: "u1", email }),
@@ -54,8 +54,8 @@ function makeRuntime() {
         agentId: "main",
         accountId: "default",
         channel: "ringcentral",
-        sessionKey: "agent:main:ringcentral:group:g1",
-        mainSessionKey: "agent:main:ringcentral:group:g1",
+        sessionKey: "agent:main:ringcentral:channel:g1",
+        mainSessionKey: "agent:main:ringcentral:channel:g1",
         lastRoutePolicy: "session",
         matchedBy: "default",
       })),
@@ -99,7 +99,7 @@ describe("handleInboundPost", () => {
     });
   });
 
-  it("dispatches allowed group messages through OpenClaw runtime", async () => {
+  it("dispatches allowed team messages through OpenClaw runtime as channel sessions", async () => {
     const runtime = makeRuntime();
     await handleInboundPost({
       post: makePost(),
@@ -117,12 +117,21 @@ describe("handleInboundPost", () => {
     });
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
     expect(runtime.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({ BodyForAgent: "hello", NativeChannelId: "g1" }),
+      expect.objectContaining({
+        BodyForAgent: "hello",
+        ChatType: "channel",
+        From: "team:g1",
+        NativeChannelId: "g1",
+      }),
+    );
+    expect(runtime.routing.resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({ peer: { kind: "channel", id: "g1" } }),
     );
   });
 
-  it("does not require mentions by default when groupPolicy is open", async () => {
+  it("requires mentions by default when groupPolicy is open", async () => {
     const runtime = makeRuntime();
+    const log = vi.fn();
     await handleInboundPost({
       post: makePost({ text: "plain group message" }),
       cfg: {},
@@ -130,14 +139,18 @@ describe("handleInboundPost", () => {
       account: resolveAccount({
         botToken: "bot",
         groupPolicy: "open",
+        debugInboundMessages: true,
         processingPlaceholder: { enabled: false },
       }),
       botPersonId: "bot",
       channelRuntime: runtime,
       tracker: new ThreadParticipationTracker(),
+      log,
     });
 
-    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    const drop = loggedMessages(log).find((message) => message.startsWith("[ringcentral] inbound message dropped "));
+    expect(drop).toContain('"reasonCode":"activation_skipped"');
   });
 
   it("honors explicit requireMention when groupPolicy is open", async () => {
@@ -328,12 +341,12 @@ describe("handleInboundPost", () => {
     const message = loggedMessages(log).find((entry) => entry.startsWith("[ringcentral] inbound message "));
     expect(message).toContain('"chatId":"g1"');
     expect(message).toContain('"creatorId":"u1"');
-    expect(message).toContain('"chatType":"group"');
+    expect(message).toContain('"chatType":"channel"');
     expect(message).toContain('"textLength":8');
     expect(message).toContain('"text":"debug me"');
   });
 
-  it("drops groups when groupPolicy is disabled", async () => {
+  it("drops teams when groupPolicy is disabled", async () => {
     const runtime = makeRuntime();
     const client = makeClient();
     await handleInboundPost({
@@ -440,7 +453,7 @@ describe("handleInboundPost", () => {
     expect(client.downloadAttachment).not.toHaveBeenCalled();
   });
 
-  it("allows DM senders by email alias", async () => {
+  it("allows DM senders by stable person ID", async () => {
     const runtime = makeRuntime();
     await handleInboundPost({
       post: makePost({ groupId: "dm1", creatorId: "u-owner" }),
@@ -448,8 +461,8 @@ describe("handleInboundPost", () => {
       botClient: makeClient("Direct", "owner@example.com"),
       account: resolveAccount({
         botToken: "bot",
-        dm: { policy: "allowlist" },
-        allowedUserEmails: ["owner@example.com"],
+        dmPolicy: "allowlist",
+        allowFrom: ["u-owner"],
         processingPlaceholder: { enabled: false },
       }),
       botPersonId: "bot",
@@ -457,6 +470,86 @@ describe("handleInboundPost", () => {
       tracker: new ThreadParticipationTracker(),
     });
     expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("rejects email allowFrom entries unless dangerous email matching is enabled", async () => {
+    const runtime = makeRuntime();
+    await handleInboundPost({
+      post: makePost({ groupId: "dm1", creatorId: "u-owner" }),
+      cfg: {},
+      botClient: makeClient("Direct", "owner@example.com"),
+      account: resolveAccount({
+        botToken: "bot",
+        dmPolicy: "allowlist",
+        allowFrom: ["owner@example.com"],
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log: vi.fn(),
+    });
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("allows email allowFrom entries when dangerous email matching is enabled", async () => {
+    const runtime = makeRuntime();
+    await handleInboundPost({
+      post: makePost({ groupId: "dm1", creatorId: "u-owner" }),
+      cfg: {},
+      botClient: makeClient("Direct", "owner@example.com"),
+      account: resolveAccount({
+        botToken: "bot",
+        dmPolicy: "allowlist",
+        allowFrom: ["owner@example.com"],
+        dangerouslyAllowEmailMatching: true,
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+    });
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+  });
+
+  it("ignores RingCentral group DMs by default", async () => {
+    const runtime = makeRuntime();
+    await handleInboundPost({
+      post: makePost({ groupId: "gdm1" }),
+      cfg: {},
+      botClient: makeClient("Group"),
+      account: resolveAccount({
+        botToken: "bot",
+        groupPolicy: "open",
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+      log: vi.fn(),
+    });
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("dispatches allowlisted RingCentral group DMs", async () => {
+    const runtime = makeRuntime();
+    await handleInboundPost({
+      post: makePost({ groupId: "gdm1" }),
+      cfg: {},
+      botClient: makeClient("Group"),
+      account: resolveAccount({
+        botToken: "bot",
+        dm: { groupEnabled: true, groupChannels: { gdm1: { allow: true, requireMention: false } } },
+        processingPlaceholder: { enabled: false },
+      }),
+      botPersonId: "bot",
+      channelRuntime: runtime,
+      tracker: new ThreadParticipationTracker(),
+    });
+    expect(runtime.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledOnce();
+    expect(runtime.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({ ChatType: "group", From: "group:gdm1" }),
+    );
   });
 
   it("downloads admitted attachments into OpenClaw inbound media payload", async () => {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -8,11 +8,33 @@ import { resolveInboundAttachmentsForAgent } from "./attachments.js";
 import { RingCentralApiError, type RingCentralClient } from "./client.js";
 import { sendMessage, sendTypingIndicator, updateMessage } from "./send.js";
 import { RINGCENTRAL_CHANNEL_ID } from "./shared.js";
-import { buildChannelTarget, buildDmTarget, buildGroupTarget } from "./targets.js";
-import { channelSetMatches, type ThreadParticipationTracker } from "./threading.js";
-import type { Chat, PersonInfo, Post, ResolvedAccount } from "./types.js";
+import { buildChannelTarget, buildGroupTarget, buildTeamTarget, buildUserTarget } from "./targets.js";
+import type { ThreadParticipationTracker } from "./threading.js";
+import type { Chat, PersonInfo, Post, ResolvedAccount, RingCentralGroupDmConfig, RingCentralTeamConfig } from "./types.js";
 
 type ChatType = "direct" | "group" | "channel";
+type ChatSurface =
+  | {
+      kind: "direct";
+      chatType: "direct";
+      targetKind: "user";
+      settings?: undefined;
+      groupPolicy: "disabled" | "allowlist" | "open";
+    }
+  | {
+      kind: "group-dm";
+      chatType: "group";
+      targetKind: "group";
+      settings?: RingCentralGroupDmConfig;
+      groupPolicy: "disabled" | "allowlist" | "open";
+    }
+  | {
+      kind: "team";
+      chatType: "channel";
+      targetKind: "team" | "channel";
+      settings?: RingCentralTeamConfig;
+      groupPolicy: "disabled" | "allowlist" | "open";
+    };
 type ResolveAgentRoute = typeof import("openclaw/plugin-sdk/routing")["resolveAgentRoute"];
 type FinalizeInboundContext =
   typeof import("openclaw/plugin-sdk/reply-runtime")["finalizeInboundContext"];
@@ -82,7 +104,8 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   const text = post.text ?? "";
   const senderId = post.creatorId;
   const chat = await getChatSafe(botClient, chatId);
-  const chatType = classifyChat(chat);
+  const surface = classifyChatSurface(chat, account, chatId);
+  const chatType = surface.chatType;
   const sender = await getPersonSafe(ownerClient ?? botClient, senderId);
 
   if (!account.config.allowBots && inCtx.botPersonId && senderId === inCtx.botPersonId) {
@@ -106,8 +129,8 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     mentions: post.mentions,
     botPersonId: inCtx.botPersonId,
   });
-  const routeDescriptors = buildRouteDescriptors({ account, chatId, chatType });
-  const groupConfig = account.config.groups?.[chatId];
+  const routeDescriptors = buildRouteDescriptors({ account, chatId, surface });
+  const surfaceConfig = surface.settings;
   const threadFollowup = isTrackedThreadFollowup(post, tracker);
   if (account.debugInboundMessages && (post.parentPostId || post.threadId)) {
     log(
@@ -117,15 +140,13 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
   const requireMention = resolveRequireMention({
     account,
     chatId,
-    chatType,
-    groupConfigRequireMention: groupConfig?.requireMention,
+    surface,
+    surfaceRequireMention: surfaceConfig?.requireMention,
     threadFollowup,
   });
-  const allowFrom = buildAllowFrom({
-    account,
-    ownerPersonId: inCtx.ownerPersonId,
-  });
-  const groupAllowFrom = groupConfig?.users ?? [];
+  const allowFrom = buildAllowFrom(account);
+  const groupAllowFrom =
+    chatType === "direct" ? [] : surfaceConfig?.users?.length ? surfaceConfig.users : ["*"];
 
   const ingressRuntime = await import("openclaw/plugin-sdk/channel-ingress-runtime");
   const ingress = await ingressRuntime.resolveChannelMessageIngress({
@@ -139,10 +160,10 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     conversation: { kind: chatType, id: chatId },
     event: { kind: "message", authMode: "inbound", mayPair: chatType === "direct" },
     policy: {
-      dmPolicy: account.allowAllUsers ? "open" : account.dmPolicy,
-      groupPolicy: account.groupPolicy,
+      dmPolicy: account.dmPolicy,
+      groupPolicy: surface.groupPolicy,
       groupAllowFromFallbackToAllowFrom: true,
-      mutableIdentifierMatching: "enabled",
+      mutableIdentifierMatching: account.dangerouslyAllowEmailMatching ? "enabled" : "disabled",
       activation: {
         requireMention,
         allowTextCommands: true,
@@ -168,8 +189,8 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
       logInboundDropDebug(log, {
         chatId,
         chatType,
-        groupConfigRequireMention: groupConfig?.requireMention,
-        groupPolicy: account.groupPolicy,
+        surfaceConfigRequireMention: surfaceConfig?.requireMention,
+        groupPolicy: surface.groupPolicy,
         reasonCode: ingress.ingress.reasonCode,
         requireMention,
         textLength: text.length,
@@ -178,8 +199,8 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
       logFirstInboundDropWarning(log, {
         chatId,
         chatType,
-        groupConfigRequireMention: groupConfig?.requireMention,
-        groupPolicy: account.groupPolicy,
+        surfaceConfigRequireMention: surfaceConfig?.requireMention,
+        groupPolicy: surface.groupPolicy,
         reasonCode: ingress.ingress.reasonCode,
         requireMention,
         textLength: text.length,
@@ -222,7 +243,7 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
       accountId: "default",
       peer,
     });
-  const target = buildInboundTarget({ chatType, chatId, senderId });
+  const target = buildInboundTarget({ surface, chatId, senderId });
   const fallbackReplyRuntime =
     runtime.reply?.finalizeInboundContext && runtime.reply?.dispatchReplyWithBufferedBlockDispatcher
       ? null
@@ -249,7 +270,7 @@ export async function handleInboundPost(inCtx: InboundContext): Promise<void> {
     ChatType: chatType,
     ConversationLabel: chat?.name ?? chatId,
     GroupChannel: chatType !== "direct" ? chatId : undefined,
-    GroupSystemPrompt: groupConfig?.systemPrompt,
+    GroupSystemPrompt: surfaceConfig?.systemPrompt,
     SenderId: senderId,
     SenderName: formatPersonName(sender),
     Timestamp: Date.parse(post.creationTime) || Date.now(),
@@ -603,53 +624,71 @@ async function sendReplyText(
   });
 }
 
-function buildAllowFrom(params: {
-  account: ResolvedAccount;
-  ownerPersonId?: string;
-}): Array<string | number> {
-  if (params.account.allowAllUsers) {
-    return ["*"];
-  }
-  const entries = [
-    ...(params.account.config.dm?.allowFrom ?? []),
-    ...params.account.allowedUserEmails,
-    ...(params.ownerPersonId ? [params.ownerPersonId] : []),
-  ];
-  return Array.from(new Set(entries.map((entry) => String(entry).trim()).filter(Boolean)));
+function buildAllowFrom(account: ResolvedAccount): Array<string | number> {
+  return account.allowFrom;
 }
 
 function buildRouteDescriptors(params: {
   account: ResolvedAccount;
   chatId: string;
-  chatType: ChatType;
+  surface: ChatSurface;
 }): ChannelIngressRouteDescriptor[] {
   const routes: ChannelIngressRouteDescriptor[] = [];
-  if (channelSetMatches(params.account.ignoredChannels, params.chatId)) {
+  if (params.surface.kind === "group-dm") {
+    if (!params.account.groupDmEnabled) {
+      routes.push({
+        id: `ringcentral:group-dm:${params.chatId}`,
+        configured: false,
+        matched: true,
+        allowed: false,
+        blockReason: "group dm disabled",
+      });
+      return routes;
+    }
     routes.push({
-      id: `ringcentral:ignored:${params.chatId}`,
+      id: `ringcentral:group-dm:${params.chatId}`,
+      configured: !!params.surface.settings,
+      matched: true,
+      allowed: !!params.surface.settings && params.surface.settings.allow !== false,
+      blockReason: "group dm not allowlisted",
+    });
+    return routes;
+  }
+
+  if (params.surface.kind !== "team") {
+    return routes;
+  }
+
+  const explicitTeamConfig = params.account.config.teams?.[params.chatId];
+  if (explicitTeamConfig?.allow === false) {
+    routes.push({
+      id: `ringcentral:team:${params.chatId}`,
       configured: true,
       matched: true,
       allowed: false,
-      blockReason: "ignored channel",
+      blockReason: "team disabled",
     });
+    return routes;
   }
-  if (params.account.allowedChannels.length > 0) {
+
+  if (params.account.groupPolicy === "allowlist") {
     routes.push({
-      id: `ringcentral:allowed:${params.chatId}`,
+      id: `ringcentral:team:${params.chatId}`,
       configured: true,
-      matched: channelSetMatches(params.account.allowedChannels, params.chatId),
-      allowed: channelSetMatches(params.account.allowedChannels, params.chatId),
-      blockReason: "channel not allowlisted",
-    });
-  }
-  if (params.chatType !== "direct" && params.account.groupPolicy === "allowlist") {
-    const groupConfig = params.account.config.groups?.[params.chatId];
-    routes.push({
-      id: `ringcentral:group:${params.chatId}`,
-      configured: !!groupConfig,
       matched: true,
-      allowed: !!groupConfig && groupConfig.enabled !== false,
-      blockReason: "group not allowlisted",
+      allowed: explicitTeamConfig !== undefined,
+      blockReason: "team not allowlisted",
+    });
+    return routes;
+  }
+
+  if (params.account.groupPolicy === "disabled") {
+    routes.push({
+      id: `ringcentral:team:${params.chatId}`,
+      configured: false,
+      matched: true,
+      allowed: false,
+      blockReason: "team policy disabled",
     });
   }
   return routes;
@@ -701,7 +740,7 @@ function logInboundDropDebug(
   details: {
     chatId: string;
     chatType: ChatType;
-    groupConfigRequireMention?: boolean;
+    surfaceConfigRequireMention?: boolean;
     groupPolicy: string;
     reasonCode: string;
     requireMention: boolean;
@@ -712,7 +751,7 @@ function logInboundDropDebug(
     `[ringcentral] inbound message dropped ${JSON.stringify({
       chatId: details.chatId,
       chatType: details.chatType,
-      groupConfigRequireMention: details.groupConfigRequireMention,
+      surfaceConfigRequireMention: details.surfaceConfigRequireMention,
       groupPolicy: details.groupPolicy,
       reasonCode: details.reasonCode,
       requireMention: details.requireMention,
@@ -726,7 +765,7 @@ function logFirstInboundDropWarning(
   details: {
     chatId: string;
     chatType: ChatType;
-    groupConfigRequireMention?: boolean;
+    surfaceConfigRequireMention?: boolean;
     groupPolicy: string;
     reasonCode: string;
     requireMention: boolean;
@@ -741,7 +780,7 @@ function logFirstInboundDropWarning(
     `[ringcentral] WARN inbound message dropped ${JSON.stringify({
       chatId: details.chatId,
       chatType: details.chatType,
-      groupConfigRequireMention: details.groupConfigRequireMention,
+      surfaceConfigRequireMention: details.surfaceConfigRequireMention,
       groupPolicy: details.groupPolicy,
       reasonCode: details.reasonCode,
       requireMention: details.requireMention,
@@ -778,26 +817,23 @@ function logInboundDispatchDiagnostic(
 function resolveRequireMention(params: {
   account: ResolvedAccount;
   chatId: string;
-  chatType: ChatType;
-  groupConfigRequireMention?: boolean;
+  surface: ChatSurface;
+  surfaceRequireMention?: boolean;
   threadFollowup: boolean;
 }): boolean {
-  if (params.chatType === "direct") {
+  if (params.surface.kind === "direct") {
     return false;
   }
-  if (
-    channelSetMatches(params.account.freeResponseChannels, params.chatId) ||
-    (params.threadFollowup && !params.account.threadRequireMention)
-  ) {
+  if (params.threadFollowup && !params.account.threadRequireMention) {
     return false;
   }
-  if (params.groupConfigRequireMention !== undefined) {
-    return params.groupConfigRequireMention;
+  if (params.surfaceRequireMention !== undefined) {
+    return params.surfaceRequireMention;
   }
   if (params.account.requireMentionExplicit) {
     return params.account.requireMention;
   }
-  return params.account.groupPolicy === "open" ? false : params.account.requireMention;
+  return params.surface.kind === "team";
 }
 
 async function getChatSafe(client: RingCentralClient, chatId: string): Promise<Chat | null> {
@@ -825,21 +861,57 @@ async function getPersonSafe(
   }
 }
 
-function classifyChat(chat: Chat | null): ChatType {
-  if (chat?.type === "Group" || chat?.type === "Team") {
-    return "group";
+function classifyChatSurface(
+  chat: Chat | null,
+  account: ResolvedAccount,
+  chatId: string,
+): ChatSurface {
+  if (chat?.type === "Direct" || chat?.type === "Personal") {
+    return {
+      kind: "direct",
+      chatType: "direct",
+      targetKind: "user",
+      groupPolicy: "disabled",
+    };
   }
-  if (chat?.type === "Everyone") {
-    return "channel";
+  if (chat?.type === "Team" || chat?.type === "Everyone") {
+    return {
+      kind: "team",
+      chatType: "channel",
+      targetKind: chat.type === "Team" ? "team" : "channel",
+      settings: resolveTeamSettings(account, chatId),
+      groupPolicy: account.groupPolicy,
+    };
   }
-  return "direct";
+  return {
+    kind: "group-dm",
+    chatType: "group",
+    targetKind: "group",
+    settings: account.groupDmChannels[chatId],
+    groupPolicy: account.groupDmEnabled ? "allowlist" : "disabled",
+  };
 }
 
-function buildInboundTarget(params: { chatType: ChatType; chatId: string; senderId: string }): string {
-  if (params.chatType === "direct") {
-    return buildDmTarget(params.senderId);
+function resolveTeamSettings(
+  account: ResolvedAccount,
+  chatId: string,
+): RingCentralTeamConfig | undefined {
+  const defaults = account.config.teams?.["*"];
+  const explicit = account.config.teams?.[chatId];
+  if (!defaults) {
+    return explicit;
   }
-  if (params.chatType === "channel") {
+  return explicit ? { ...defaults, ...explicit } : defaults;
+}
+
+function buildInboundTarget(params: { surface: ChatSurface; chatId: string; senderId: string }): string {
+  if (params.surface.targetKind === "user") {
+    return buildUserTarget(params.senderId);
+  }
+  if (params.surface.targetKind === "team") {
+    return buildTeamTarget(params.chatId);
+  }
+  if (params.surface.targetKind === "channel") {
     return buildChannelTarget(params.chatId);
   }
   return buildGroupTarget(params.chatId);

--- a/src/live/ringcentral-live.test.ts
+++ b/src/live/ringcentral-live.test.ts
@@ -1315,7 +1315,7 @@ async function readHistoryToolText(params: {
     },
   });
   const result = await tool.execute("ringcentral-live-smoke", {
-    target: `ringcentral:chat:${params.chatId}`,
+    target: `channel:${params.chatId}`,
     target_type: "chat",
     record_count: params.recordCount,
   });

--- a/src/targets.test.ts
+++ b/src/targets.test.ts
@@ -1,55 +1,69 @@
-import { describe, it, expect } from "vitest";
-import { parseTarget, buildTarget, buildDmTarget, buildGroupTarget, extractChatId, normalizeTarget } from "./targets.js";
+import { describe, expect, it } from "vitest";
+import {
+  buildChannelTarget,
+  buildDmTarget,
+  buildGroupTarget,
+  buildTarget,
+  buildTeamTarget,
+  buildUserTarget,
+  extractChatId,
+  extractTargetId,
+  normalizeTarget,
+  parseTarget,
+} from "./targets.js";
 
 describe("parseTarget", () => {
-  it("parses ringcentral:dm:123", () => {
-    expect(parseTarget("ringcentral:dm:123")).toEqual({ kind: "dm", id: "123" });
+  it("parses canonical targets", () => {
+    expect(parseTarget("user:123")).toEqual({ kind: "user", id: "123" });
+    expect(parseTarget("team:t1")).toEqual({ kind: "team", id: "t1" });
+    expect(parseTarget("group:g1")).toEqual({ kind: "group", id: "g1" });
+    expect(parseTarget("channel:c1")).toEqual({ kind: "channel", id: "c1" });
   });
 
-  it("parses rc:chat:456", () => {
-    expect(parseTarget("rc:chat:456")).toEqual({ kind: "chat", id: "456" });
-  });
-
-  it("parses bare numeric ID", () => {
-    expect(parseTarget("789")).toEqual({ kind: "chat", id: "789" });
+  it("rejects legacy provider-prefixed targets and bare IDs", () => {
+    expect(parseTarget("ringcentral:dm:123")).toBeNull();
+    expect(parseTarget("rc:chat:456")).toBeNull();
+    expect(parseTarget("789")).toBeNull();
   });
 
   it("returns null for unknown format", () => {
     expect(parseTarget("unknown:format")).toBeNull();
+    expect(parseTarget("user:")).toBeNull();
   });
 });
 
 describe("buildTarget", () => {
-  it("builds target string", () => {
-    expect(buildTarget("dm", "123")).toBe("ringcentral:dm:123");
-  });
-});
-
-describe("buildDmTarget", () => {
-  it("builds DM target", () => {
-    expect(buildDmTarget("123")).toBe("ringcentral:dm:123");
-  });
-});
-
-describe("buildGroupTarget", () => {
-  it("builds group target", () => {
-    expect(buildGroupTarget("456")).toBe("ringcentral:group:456");
+  it("builds target strings", () => {
+    expect(buildTarget("user", "123")).toBe("user:123");
+    expect(buildUserTarget("123")).toBe("user:123");
+    expect(buildDmTarget("123")).toBe("user:123");
+    expect(buildTeamTarget("456")).toBe("team:456");
+    expect(buildGroupTarget("456")).toBe("group:456");
+    expect(buildChannelTarget("789")).toBe("channel:789");
   });
 });
 
 describe("extractChatId", () => {
-  it("extracts chat ID from target", () => {
-    expect(extractChatId("ringcentral:dm:123")).toBe("123");
+  it("extracts chat IDs from chat-backed targets", () => {
+    expect(extractChatId("team:t1")).toBe("t1");
+    expect(extractChatId("group:g1")).toBe("g1");
+    expect(extractChatId("channel:c1")).toBe("c1");
   });
 
-  it("returns null for invalid target", () => {
-    expect(extractChatId("invalid")).toBeNull();
+  it("does not treat user targets as chat IDs", () => {
+    expect(extractChatId("user:u1")).toBeNull();
+  });
+});
+
+describe("extractTargetId", () => {
+  it("extracts the raw target ID", () => {
+    expect(extractTargetId("user:u1")).toBe("u1");
   });
 });
 
 describe("normalizeTarget", () => {
-  it("normalizes target", () => {
-    expect(normalizeTarget("rc:dm:123")).toBe("ringcentral:dm:123");
+  it("normalizes canonical target spacing", () => {
+    expect(normalizeTarget(" team:t1 ")).toBe("team:t1");
   });
 
   it("returns undefined for unknown format", () => {

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -1,34 +1,39 @@
 // Target ID normalization for RingCentral.
-// Format: rc:{kind}:{id} where kind is dm, group, channel, user, chat
+// Canonical format follows OpenClaw message targets:
+// user:<personId>, team:<chatId>, group:<chatId>, or channel:<chatId>.
 
-export const RC_PREFIX = "ringcentral";
+export type RingCentralTargetKind = "user" | "team" | "group" | "channel";
 
-export function parseTarget(raw: string): { kind: string; id: string } | null {
-  // ringcentral:dm:123 or ringcentral:group:123 or rc:chat:123
-  const prefixes = [`${RC_PREFIX}:`, "rc:"];
-  for (const prefix of prefixes) {
-    if (raw.startsWith(prefix)) {
-      const rest = raw.slice(prefix.length);
-      const colonIdx = rest.indexOf(":");
-      if (colonIdx > 0) {
-        return { kind: rest.slice(0, colonIdx), id: rest.slice(colonIdx + 1) };
-      }
-      return { kind: "chat", id: rest };
-    }
+const TARGET_KINDS = new Set<string>(["user", "team", "group", "channel"]);
+
+export function parseTarget(raw: string): { kind: RingCentralTargetKind; id: string } | null {
+  const target = raw.trim();
+  if (target.startsWith("ringcentral:") || target.startsWith("rc:")) {
+    return null;
   }
-  // Bare numeric ID
-  if (/^\d+$/.test(raw)) {
-    return { kind: "chat", id: raw };
+  const colonIdx = target.indexOf(":");
+  if (colonIdx <= 0) {
+    return null;
   }
-  return null;
+  const kind = target.slice(0, colonIdx);
+  const id = target.slice(colonIdx + 1).trim();
+  return TARGET_KINDS.has(kind) && id ? { kind: kind as RingCentralTargetKind, id } : null;
 }
 
-export function buildTarget(kind: string, id: string): string {
-  return `${RC_PREFIX}:${kind}:${id}`;
+export function buildTarget(kind: RingCentralTargetKind, id: string): string {
+  return `${kind}:${id}`;
 }
 
 export function buildDmTarget(userId: string): string {
-  return buildTarget("dm", userId);
+  return buildTarget("user", userId);
+}
+
+export function buildUserTarget(userId: string): string {
+  return buildTarget("user", userId);
+}
+
+export function buildTeamTarget(chatId: string): string {
+  return buildTarget("team", chatId);
 }
 
 export function buildGroupTarget(chatId: string): string {
@@ -41,7 +46,11 @@ export function buildChannelTarget(chatId: string): string {
 
 export function extractChatId(target: string): string | null {
   const parsed = parseTarget(target);
-  return parsed?.id ?? null;
+  return parsed && parsed.kind !== "user" ? parsed.id : null;
+}
+
+export function extractTargetId(target: string): string | null {
+  return parseTarget(target)?.id ?? null;
 }
 
 export function normalizeTarget(raw: string): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,23 @@ export interface AttachmentDownloadConfig {
   maxBytes?: number;
 }
 
+export type RingCentralDmPolicy = "disabled" | "allowlist" | "pairing" | "open";
+export type RingCentralGroupPolicy = "disabled" | "allowlist" | "open";
+
+export interface RingCentralTeamConfig {
+  allow?: boolean;
+  requireMention?: boolean;
+  systemPrompt?: string;
+  users?: Array<string | number>;
+}
+
+export interface RingCentralGroupDmConfig {
+  allow?: boolean;
+  requireMention?: boolean;
+  systemPrompt?: string;
+  users?: Array<string | number>;
+}
+
 export interface RingCentralConfig {
   enabled?: boolean;
   name?: string;
@@ -214,11 +231,15 @@ export interface RingCentralConfig {
   server?: string;
   botExtensionId?: string;
   selfOnly?: boolean;
-  allowedUserEmails?: string[];
-  allowAllUsers?: boolean;
-  allowedChannels?: string[];
-  ignoredChannels?: string[];
-  freeResponseChannels?: string[];
+  dmPolicy?: RingCentralDmPolicy;
+  allowFrom?: Array<string | number>;
+  dangerouslyAllowEmailMatching?: boolean;
+  groupPolicy?: RingCentralGroupPolicy;
+  teams?: Record<string, RingCentralTeamConfig>;
+  dm?: {
+    groupEnabled?: boolean;
+    groupChannels?: Record<string, RingCentralGroupDmConfig>;
+  };
   threadRequireMention?: boolean;
   noThreadChannels?: string[];
   replyToMode?: RingCentralReplyToMode;
@@ -228,13 +249,7 @@ export interface RingCentralConfig {
   historyMessageLimit?: number;
   homeChannel?: string;
   homeChannelName?: string;
-  groupPolicy?: "disabled" | "allowlist" | "open";
-  groups?: Record<string, GroupConfig>;
   requireMention?: boolean;
-  dm?: {
-    policy?: "disabled" | "allowlist" | "pairing" | "open";
-    allowFrom?: Array<string | number>;
-  };
   textChunkLimit?: number;
   allowBots?: boolean;
   workspace?: string;
@@ -248,31 +263,23 @@ export interface RingCentralConfig {
   };
 }
 
-export interface GroupConfig {
-  enabled?: boolean;
-  requireMention?: boolean;
-  systemPrompt?: string;
-  users?: Array<string | number>;
-}
-
 export interface ResolvedAccount {
   botToken: string;
   ownerCredentials?: ResolvedRingCentralOwnerCredentials;
   /** @deprecated Use ownerCredentials. */
   credentials?: ResolvedRingCentralOwnerCredentials;
   server: string;
-  allowedUserEmails: string[];
-  allowAllUsers: boolean;
-  allowedChannels: string[];
-  ignoredChannels: string[];
-  freeResponseChannels: string[];
+  allowFrom: string[];
+  dangerouslyAllowEmailMatching: boolean;
+  groupDmEnabled: boolean;
+  groupDmChannels: Record<string, RingCentralGroupDmConfig>;
   noThreadChannels: string[];
   replyToMode: RingCentralReplyToMode;
   requireMention: boolean;
   requireMentionExplicit: boolean;
   threadRequireMention: boolean;
-  groupPolicy: "disabled" | "allowlist" | "open";
-  dmPolicy: "disabled" | "allowlist" | "pairing" | "open";
+  groupPolicy: RingCentralGroupPolicy;
+  dmPolicy: RingCentralDmPolicy;
   textChunkLimit?: number;
   processingPlaceholder: Required<ProcessingPlaceholderConfig>;
   attachments: Required<AttachmentDownloadConfig>;


### PR DESCRIPTION
## Summary
- Reworks `openclaw-ringcentral` DM, group DM, and team/channel handling around Discord/OpenClaw-style configuration.
- Introduces canonical policies for DMs, Team/Everyone surfaces, and RingCentral group DMs.
- Adds breaking migration errors for legacy access-control fields, legacy env vars, bare numeric targets, and old `ringcentral:*`/`rc:*` target formats.

## Behavior Changes
- New config surface:
  - `dmPolicy`: `pairing | allowlist | open | disabled`, defaulting to `pairing`.
  - `allowFrom`: stable person ID allowlist for DMs.
  - `dangerouslyAllowEmailMatching`: explicit opt-in before email alias matching is accepted.
  - `groupPolicy`: controls Team/Everyone surfaces.
  - `teams.<chatId>` and `teams."*"` for team/channel routing defaults.
  - `dm.groupEnabled` and `dm.groupChannels.<chatId>` for RingCentral group DMs, defaulting group DMs off.
- Maps RingCentral chat types as:
  - `Direct`/`Personal` -> DM (`user:<personId>`).
  - `Group` -> group DM (`group:<chatId>`), ignored unless explicitly enabled and allowed.
  - `Team`/`Everyone` -> channel/team surface (`team:<chatId>` or `channel:<chatId>`), with channel-style session peers.
- Updates outbound target resolution:
  - `user:<personId>` creates or finds the DM before sending.
  - `team:<chatId>`, `channel:<chatId>`, and `group:<chatId>` send directly by chat ID.

## Migration Notes
- Removed legacy config fields are rejected with migration guidance:
  - `allowedUserEmails`, `allowAllUsers`, `allowedChannels`, `ignoredChannels`, `freeResponseChannels`, `groups`, `dm.policy`, `dm.allowFrom`.
- Removed legacy env vars are rejected with migration guidance:
  - `RC_ALLOWED_USER_EMAILS`, `RC_ALLOW_ALL_USERS`, `RC_ALLOWED_CHANNELS`, `RC_IGNORED_CHANNELS`, `RC_FREE_RESPONSE_CHANNELS`.
- Legacy targets are rejected:
  - Bare numeric IDs.
  - `ringcentral:*` and `rc:*` targets.
- Team/Everyone bindings now use channel-style sessions instead of the previous `group:<id>` compatibility shape.

## Docs and Manifest
- Updates `README.md` with the new config model, target examples, and migration table.
- Updates `openclaw.plugin.json` labels and config schema to reflect the new canonical fields.

## Testing
- `pnpm typecheck`
- `pnpm test` (`224 passed | 1 skipped`)
- `pnpm build`
- `git diff --check`

No live RingCentral E2E was run.
