### PR TITLE
Allow bot artifact tools in allowlisted RingCentral chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,36 @@
 # OpenClaw RingCentral Channel
 
 [![npm version](https://img.shields.io/npm/v/openclaw-ringcentral)](https://www.npmjs.com/package/openclaw-ringcentral)
-[![Release](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/release.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/release.yml)
 [![CI](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ci.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ci.yml)
-[![RingCentral Live Smoke](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ringcentral-live-smoke.yml/badge.svg)](https://github.com/ringclaw/openclaw-ringcentral/actions/workflows/ringcentral-live-smoke.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ringclaw_openclaw-ringcentral&metric=alert_status)](https://sonarcloud.io/dashboard?id=ringclaw_openclaw-ringcentral)
 
 RingCentral Team Messaging channel plugin for OpenClaw.
 
-## Install
+## Overview
 
-Install the published plugin package through the OpenClaw plugin manager:
+Use this plugin when you want an OpenClaw agent to receive and send RingCentral
+Team Messaging conversations through a RingCentral Bot Add-in.
+
+It supports:
+
+- Direct messages with `pairing`, `allowlist`, `open`, or `disabled` policy.
+- RingCentral `Team` and `Everyone` chats as channel surfaces.
+- RingCentral `Group` conversations as group DMs, disabled by default and enabled only by explicit allowlist.
+- Threaded replies, mention gates, per-chat user allowlists, and per-chat system prompts.
+- Inbound file/image attachment download into OpenClaw managed media storage.
+- Shared OpenClaw `message` actions for send/read/edit/delete/channel-info.
+- Optional `ringcentral_get_recent_messages`, Adaptive Card, note, and calendar event tools.
+
+RingCentral `Team` chats are topic-oriented chats, while `Group` conversations
+are member-set conversations. See the RingCentral Team Messaging
+[Teams documentation](https://developers.ringcentral.com/guide/team-messaging/concepts/teams)
+for the platform model this plugin follows.
+
+## Human Install
+
+### 1. Install The Plugin
+
+Install through the OpenClaw plugin manager:
 
 ```bash
 openclaw plugins install npm:openclaw-ringcentral
@@ -18,25 +38,21 @@ openclaw plugins enable ringcentral
 openclaw gateway restart
 ```
 
-The explicit `npm:` source matches OpenClaw's plugin install contract and lets
-OpenClaw manage plugin registration, policy updates, and Gateway reloads.
-Use `npm install openclaw-ringcentral` only when inspecting the package or doing
-manual development outside the OpenClaw plugin manager.
+Use `npm install openclaw-ringcentral` only for package inspection or local
+plugin development. Normal OpenClaw installs should go through the plugin
+manager so OpenClaw can register the channel, tool contracts, and hook metadata.
 
-## Features
+### 2. Create A RingCentral Bot
 
-- Bot Add-in WebSocket ingress and outbound replies
-- Optional owner JWT credentials for owner-observed chats, history reads, and fallback sends
-- OpenClaw channel ingress policy for DM pairing/allowlists, Team allowlists, group DM allowlists, and mention gates
-- Threaded replies with `off`, `first`, and `all` modes
-- Thread follow-up detection: once the bot participates in a thread, subsequent messages in that thread can skip the mention requirement (controlled by `threadRequireMention`)
-- Inbound file/image attachments are downloaded into OpenClaw managed media storage after admission
-- Optional opt-in processing placeholder while an agent run is active
-- Shared OpenClaw `message` actions for send/read/edit/delete/channel-info
-- Optional `ringcentral_get_recent_messages` agent tool
-- Dispatch lifecycle diagnostics (`debugInboundMessages`) for troubleshooting silent message drops
+Create a RingCentral Bot Add-in app with Team Messaging and WebSocket
+Subscriptions permissions, then copy the bot static token.
 
-## Configuration
+Optional owner credentials are only needed for owner-backed operations such as
+recent message history and Home-confirmed note/calendar writes. If you need
+those flows, create a JWT REST API app for the owner user with Team Messaging,
+WebSocket Subscriptions, Read Accounts, and Read Messages permissions.
+
+### 3. Configure The Channel
 
 Minimal bot-only config:
 
@@ -51,158 +67,13 @@ Minimal bot-only config:
 }
 ```
 
-Owner credentials for history/fallback:
+The same bot token can also be supplied as `RC_BOT_TOKEN`.
 
-```json
-{
-  "channels": {
-    "ringcentral": {
-      "enabled": true,
-      "botToken": "your-bot-static-token",
-      "ownerCredentials": {
-        "clientId": "your-client-id",
-        "clientSecret": "your-client-secret",
-        "jwt": "your-owner-jwt-token"
-      }
-    }
-  },
-  "tools": {
-    "allow": ["ringcentral_get_recent_messages"]
-  }
-}
-```
+### 4. Route RingCentral To An Agent
 
-`credentials` is still accepted as a deprecated alias for `ownerCredentials`.
-
-Team allowlist with per-team mention gate and thread follow-up:
-
-```json
-{
-  "channels": {
-    "ringcentral": {
-      "enabled": true,
-      "botToken": "your-bot-static-token",
-      "groupPolicy": "allowlist",
-      "threadRequireMention": false,
-      "teams": {
-        "*": {
-          "requireMention": true
-        },
-        "123456789": {
-          "allow": true,
-          "requireMention": true,
-          "users": ["sender-id-1", "sender-id-2"]
-        }
-      }
-    }
-  }
-}
-```
-
-`Team` and `Everyone` chats are treated as channel surfaces. `teams."*"` is only
-for defaults such as `requireMention`; it does not allowlist every team.
-
-When `threadRequireMention` is `false`, replies inside a thread the bot has
-already participated in do not need a new mention to activate the bot.
-Default is `true` (every message in a thread needs a mention).
-
-RingCentral `Group` conversations are treated like Discord group DMs and are
-ignored by default. Enable only explicit group DM conversations:
-
-```json
-{
-  "channels": {
-    "ringcentral": {
-      "dm": {
-        "groupEnabled": true,
-        "groupChannels": {
-          "987654321": {
-            "allow": true,
-            "requireMention": false,
-            "users": ["sender-id-1"]
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-Opt in to the processing placeholder (shown while an agent run is active):
-
-```json
-{
-  "channels": {
-    "ringcentral": {
-      "processingPlaceholder": {
-        "enabled": true,
-        "initialText": "👀",
-        "delayedText": "⏳",
-        "editDelaySeconds": 2
-      }
-    }
-  }
-}
-```
-
-DM policy and sender allowlist:
-
-```json
-{
-  "channels": {
-    "ringcentral": {
-      "dmPolicy": "allowlist",
-      "allowFrom": ["sender-id-1"]
-    }
-  }
-}
-```
-
-`dmPolicy` can be `disabled`, `allowlist`, `pairing`, or `open`. The default is
-`pairing`. `dmPolicy: "open"` requires `allowFrom: ["*"]`.
-
-`allowFrom` matches stable RingCentral person IDs by default. Email matching is
-disabled unless `dangerouslyAllowEmailMatching: true` is set.
-
-## Targets
-
-Canonical outbound targets are provider-neutral and use the selected
-`ringcentral` channel to determine transport:
-
-| Target | Description |
-| --- | --- |
-| `user:<personId>` | Create/find a DM with that RingCentral person, then send |
-| `team:<chatId>` | Send to a RingCentral Team chat |
-| `channel:<chatId>` | Send to an Everyone/channel chat |
-| `group:<chatId>` | Send to an explicitly configured RingCentral Group conversation |
-
-Legacy `ringcentral:*`, `rc:*`, and bare numeric targets are rejected.
-
-## Breaking Migration
-
-This release intentionally removes the old access-control shape:
-
-| Old | New |
-| --- | --- |
-| `allowedUserEmails` | `allowFrom` with stable person IDs |
-| `allowAllUsers` | `dmPolicy: "open"` plus `allowFrom: ["*"]` |
-| `allowedChannels` | `teams` |
-| `ignoredChannels` | omit or set `teams.<id>.allow=false` |
-| `freeResponseChannels` | `teams.<id>.requireMention=false` |
-| `groups` | `teams` |
-| `dm.policy` | `dmPolicy` |
-| `dm.allowFrom` | `allowFrom` |
-
-The corresponding legacy env vars (`RC_ALLOWED_USER_EMAILS`,
-`RC_ALLOW_ALL_USERS`, `RC_ALLOWED_CHANNELS`, `RC_IGNORED_CHANNELS`, and
-`RC_FREE_RESPONSE_CHANNELS`) are rejected with migration errors.
-
-## Pair With A Dedicated Agent
-
-Route RingCentral traffic to its own agent instead of the default webchat/TUI
-agent. This keeps operator debugging history out of RingCentral conversations
-and prevents a global coding `tools.profile` from removing the optional
-`ringcentral_*` tools.
+Use a dedicated agent for RingCentral traffic. This keeps RingCentral
+conversation state separate from webchat/TUI debugging and avoids global coding
+tool profiles hiding optional `ringcentral_*` tools.
 
 ```json
 {
@@ -231,14 +102,318 @@ and prevents a global coding `tools.profile` from removing the optional
 }
 ```
 
-`tools.profile: null` is intentional: the RingCentral agent should not inherit a
-global coding profile that removes channel tools such as
-`ringcentral_get_recent_messages`, `ringcentral_create_calendar_event`,
-`ringcentral_create_note`, or `ringcentral_create_adaptive_card`.
+Set `tools.allow` only for optional tools you want the RingCentral agent to use.
 
-## Environment
+## AI-Assisted Install
 
-Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally ignored.
+When installing this plugin for a user, use this checklist:
+
+1. Inspect the existing OpenClaw config for `channels.ringcentral`, existing
+   `agents`, and existing `bindings`.
+2. Install and enable the plugin through OpenClaw's plugin manager, not by
+   manually editing package files.
+3. Ask for or provision the RingCentral bot static token, then set
+   `channels.ringcentral.botToken` or `RC_BOT_TOKEN`.
+4. Write canonical config under `channels.ringcentral`. Do not add legacy
+   fields such as `allowedChannels`, `allowedUserEmails`, or `groups`.
+5. Prefer stable RingCentral person IDs for DM allowlists and explicit chat IDs
+   for Team/Group allowlists.
+6. Add a dedicated `ringcentral-bot` agent and channel binding unless the user
+   already has a clear RingCentral-specific agent.
+7. Enable optional `ringcentral_*` tools only when requested. Keep
+   `tools.profile: null` on the RingCentral agent if the user's global profile
+   would hide channel tools.
+8. For artifact tools in RingCentral Teams or Group DMs, ensure the target chat
+   is explicitly allowlisted with `teams.<chatId>.allow=true` or
+   `dm.groupChannels.<chatId>.allow=true`.
+9. Restart the OpenClaw gateway and verify the bot can receive one admitted
+   message and send one reply.
+
+Example AI-generated config patch:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token",
+      "dmPolicy": "pairing",
+      "groupPolicy": "allowlist",
+      "teams": {
+        "123456789": {
+          "allow": true,
+          "requireMention": true
+        }
+      }
+    }
+  },
+  "agents": {
+    "list": [
+      {
+        "id": "ringcentral-bot",
+        "tools": {
+          "profile": null
+        }
+      }
+    ]
+  },
+  "bindings": [
+    {
+      "agentId": "ringcentral-bot",
+      "match": {
+        "channel": "ringcentral"
+      }
+    }
+  ]
+}
+```
+
+## Configuration Recipes
+
+### Bot-Only Default
+
+This is enough for paired DMs and bot-authenticated sends:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token"
+    }
+  }
+}
+```
+
+### DM Allowlist
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token",
+      "dmPolicy": "allowlist",
+      "allowFrom": ["sender-person-id"]
+    }
+  }
+}
+```
+
+`dmPolicy` defaults to `pairing`. `dmPolicy: "open"` requires
+`allowFrom: ["*"]`. `allowFrom` matches stable RingCentral person IDs by
+default. Email matching is disabled unless `dangerouslyAllowEmailMatching: true`
+is set.
+
+### Team Allowlist
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token",
+      "groupPolicy": "allowlist",
+      "teams": {
+        "*": {
+          "requireMention": true
+        },
+        "123456789": {
+          "allow": true,
+          "requireMention": true,
+          "users": ["sender-person-id"],
+          "systemPrompt": "Answer as the RingCentral support bot."
+        }
+      }
+    }
+  }
+}
+```
+
+`teams."*"` is only a default entry. It can provide settings such as
+`requireMention`, but it does not allow every Team and does not authorize the
+artifact bot-token path.
+
+### Group DM Allowlist
+
+RingCentral `Group` conversations are ignored by default. Enable only explicit
+group DMs:
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token",
+      "dm": {
+        "groupEnabled": true,
+        "groupChannels": {
+          "987654321": {
+            "allow": true,
+            "requireMention": false,
+            "users": ["sender-person-id"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Threads And Replies
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "replyToMode": "first",
+      "threadRequireMention": false,
+      "noThreadChannels": ["123456789"]
+    }
+  }
+}
+```
+
+`replyToMode` can be `off`, `first`, or `all`. When
+`threadRequireMention=false`, replies inside a thread where the bot already
+participated can activate the bot without a new mention.
+
+### Attachments And Processing Placeholder
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "attachments": {
+        "enabled": true,
+        "maxCount": 5,
+        "maxBytes": 5242880
+      },
+      "processingPlaceholder": {
+        "enabled": true,
+        "initialText": "Working...",
+        "delayedText": "Still working...",
+        "editDelaySeconds": 2
+      }
+    }
+  }
+}
+```
+
+### Artifact Tools
+
+Enable only the artifact tools your RingCentral agent should use:
+
+```json
+{
+  "tools": {
+    "allow": [
+      "ringcentral_create_adaptive_card",
+      "ringcentral_create_note",
+      "ringcentral_create_calendar_event"
+    ]
+  }
+}
+```
+
+Artifact target resolution order is:
+
+1. Explicit `chat_id`, `chatId`, or `target`.
+2. Current RingCentral Team/Group chat injected by the plugin's
+   `before_tool_call` hook.
+3. `homeChannel` or `RC_HOME_CHANNEL`.
+
+If the resolved chat is explicitly allowlisted with
+`teams.<chatId>.allow=true` or `dm.groupChannels.<chatId>.allow=true`, Adaptive
+Card, note, and calendar event artifact tools use the bot token directly. Bot
+token failures are returned directly and do not fall back to owner credentials.
+
+For object-ID tools such as `ringcentral_get_note`,
+`ringcentral_update_note`, `ringcentral_get_calendar_event`, and
+`ringcentral_delete_adaptive_card`, `chat_id` is only the authorization context.
+The RingCentral API still operates on the object ID.
+
+When OpenClaw supplies agent-scoped config to a channel tool, artifact tools
+fall back to the plugin runtime's full OpenClaw config before reading
+`RC_TEAMS` or `RC_GROUP_DM_CHANNELS`. Normal JSON config under
+`channels.ringcentral` therefore remains authoritative for artifact allowlists.
+
+### Owner Credentials And Home Confirmation
+
+```json
+{
+  "channels": {
+    "ringcentral": {
+      "enabled": true,
+      "botToken": "your-bot-static-token",
+      "homeChannel": "home-chat-id",
+      "homeChannelName": "RingCentral Home",
+      "ownerCredentials": {
+        "clientId": "owner-app-client-id",
+        "clientSecret": "owner-app-client-secret",
+        "jwt": "owner-jwt-token"
+      }
+    }
+  },
+  "tools": {
+    "allow": ["ringcentral_get_recent_messages"]
+  }
+}
+```
+
+`homeChannel` is the default chat for history/artifact tools when neither an
+explicit target nor a current RingCentral Team/Group target is available. For
+non-allowlisted targets, owner-backed note and calendar writes keep the Home
+confirmation flow through `ringcentral_confirm_artifact_action`. Owner-backed
+reads outside Home are rejected. Adaptive Card tools are bot-token tools and
+require Home or an allowlisted target.
+
+`credentials` is still accepted as a deprecated alias for `ownerCredentials`,
+but new configs should use `ownerCredentials`.
+
+## Targets And Tools
+
+### Canonical Targets
+
+| Target | Description |
+| --- | --- |
+| `user:<personId>` | Create/find a DM with that RingCentral person, then send |
+| `team:<chatId>` | Send to a RingCentral Team chat |
+| `channel:<chatId>` | Send to a RingCentral Everyone/channel chat |
+| `group:<chatId>` | Send to an explicitly configured RingCentral Group conversation |
+
+Legacy `ringcentral:*`, `rc:*`, and bare numeric targets are rejected with a
+migration error.
+
+### Shared Message Actions
+
+The shared OpenClaw `message` tool exposes these RingCentral actions when the
+channel is configured:
+
+| Action | Description |
+| --- | --- |
+| `send` | Send a message |
+| `read` | Read recent messages |
+| `edit` | Edit a message |
+| `delete` | Delete a message |
+| `channel-info` | Read chat metadata |
+
+### Optional RingCentral Tools
+
+| Tool family | Tool names |
+| --- | --- |
+| History | `ringcentral_get_recent_messages` |
+| Adaptive Cards | `ringcentral_create_adaptive_card`, `ringcentral_get_adaptive_card`, `ringcentral_update_adaptive_card`, `ringcentral_delete_adaptive_card` |
+| Notes | `ringcentral_list_notes`, `ringcentral_create_note`, `ringcentral_get_note`, `ringcentral_update_note`, `ringcentral_delete_note`, `ringcentral_publish_note` |
+| Calendar Events | `ringcentral_list_calendar_events`, `ringcentral_create_calendar_event`, `ringcentral_get_calendar_event`, `ringcentral_update_calendar_event`, `ringcentral_delete_calendar_event` |
+| Confirmation | `ringcentral_confirm_artifact_action` |
+
+## Reference
+
+### Environment Variables
+
+Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally
+ignored.
 
 | Variable | Description |
 | --- | --- |
@@ -249,163 +424,75 @@ Use `RC_*` variables only. Existing `RINGCENTRAL_*` variables are intentionally 
 | `RC_USER_JWT_TOKEN` | Owner JWT token |
 | `RC_DM_POLICY` | `disabled`, `allowlist`, `pairing`, or `open`; default `pairing` |
 | `RC_ALLOW_FROM` | Comma-separated stable person IDs allowed for DMs |
-| `RC_GROUP_POLICY` | Team policy: `disabled`, `allowlist`, or `open`; default `disabled` |
+| `RC_GROUP_POLICY` | Team/Everyone policy: `disabled`, `allowlist`, or `open`; default `disabled` |
 | `RC_TEAMS` | JSON object of Team configurations keyed by chat ID |
 | `RC_TEAM_REQUIRE_MENTION` | Wildcard Team mention default |
-| `RC_GROUP_DM_ENABLED` | Enable explicitly configured RingCentral Group conversations |
+| `RC_GROUP_DM_ENABLED` | Enable explicitly configured RingCentral Group DM conversations |
 | `RC_GROUP_DM_CHANNELS` | JSON object of Group DM configurations keyed by chat ID |
-| `RC_REQUIRE_MENTION` | Global Team mention override |
+| `RC_REQUIRE_MENTION` | Global Team/Everyone mention override |
 | `RC_THREAD_REQUIRE_MENTION` | Require mention in thread follow-ups, default `true` |
 | `RC_NO_THREAD_CHANNELS` | Channels where replies must be unthreaded |
 | `RC_REPLY_TO_MODE` | `off`, `first`, or `all`; default `first` |
 | `RC_PROCESSING_EMOJI_ENABLED` | Enable processing placeholder, default `false` |
 | `RC_PROCESSING_EMOJI_EDIT_DELAY_SECONDS` | Delay before placeholder update |
-| `RC_DEBUG_INBOUND_MESSAGES` | Log detailed inbound message metadata (postId, parentPostId, threadId), default `false` |
+| `RC_DEBUG_INBOUND_MESSAGES` | Log inbound message metadata, default `false` |
 | `RC_ATTACHMENT_DOWNLOAD_ENABLED` | Download admitted inbound attachments, default `true` |
 | `RC_ATTACHMENT_MAX_COUNT` | Max attachments per inbound message, default `5` |
 | `RC_ATTACHMENT_MAX_BYTES` | Max bytes per downloaded attachment, default `5242880` |
 | `RC_HISTORY_MESSAGE_LIMIT` | Default history record count, max `1000` |
-| `RC_HOME_CHANNEL` | Default history/home chat ID |
-| `RC_HOME_CHANNEL_NAME` | Display name for the home chat |
+| `RC_HOME_CHANNEL` | Default Home chat for history/artifact tools and owner confirmations |
+| `RC_HOME_CHANNEL_NAME` | Display name for the Home chat |
 
-## Key Options
+### Key Options
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `dmPolicy` | `pairing` | `disabled`, `allowlist`, `pairing`, or `open` |
-| `allowFrom` | `[]` | Stable person IDs allowed in DMs |
-| `dangerouslyAllowEmailMatching` | `false` | Allow matching `allowFrom` against email aliases |
+| `dmPolicy` | `pairing` | Direct message handling: `disabled`, `allowlist`, `pairing`, or `open` |
+| `allowFrom` | `[]` | Stable RingCentral person IDs allowed in DMs |
+| `dangerouslyAllowEmailMatching` | `false` | Match `allowFrom` against email aliases |
 | `groupPolicy` | `disabled` | Team/Everyone handling: `disabled`, `allowlist`, or `open` |
-| `requireMention` | `true` | Global Team mention override |
-| `threadRequireMention` | `true` | Require mention in thread follow-ups (set `false` to allow follow-up replies without mention) |
-| `teams.<chatId>.allow` | `true` | Enable an allowlisted Team |
-| `teams.<chatId>.requireMention` | inherited | Per-Team mention gate |
-| `teams.<chatId>.users` | `[]` | Per-Team sender allowlist |
-| `teams.<chatId>.systemPrompt` | — | Per-Team system prompt override |
-| `dm.groupEnabled` | `false` | Enable explicitly configured RingCentral Group conversations |
-| `dm.groupChannels.<chatId>.allow` | `true` | Enable an allowlisted group DM |
-| `dm.groupChannels.<chatId>.requireMention` | `false` | Per-group-DM mention gate |
-| `dm.groupChannels.<chatId>.users` | `[]` | Per-group-DM sender allowlist |
-| `replyToMode` | `first` | Threading behavior for replies (`off`, `first`, `all`) |
-| `noThreadChannels` | `[]` | Chat IDs that force unthreaded sends |
-| `processingPlaceholder.enabled` | `false` | Show emoji placeholder while agent is processing |
-| `processingPlaceholder.initialText` | `👀` | Initial placeholder text |
-| `processingPlaceholder.delayedText` | `⏳` | Text shown after edit delay |
-| `processingPlaceholder.editDelaySeconds` | `2` | Seconds before switching to `delayedText` |
+| `teams.<chatId>.allow` | `true` when present | Enable an explicit Team/Everyone chat |
+| `teams."*"` | none | Defaults only; not an allowlist entry |
+| `dm.groupEnabled` | `false` | Enable explicit RingCentral Group DM conversations |
+| `dm.groupChannels.<chatId>.allow` | `true` when present | Enable an explicit group DM |
+| `requireMention` | `true` | Global Team/Everyone mention gate |
+| `threadRequireMention` | `true` | Require mention in thread follow-ups |
+| `replyToMode` | `first` | Threading behavior for replies: `off`, `first`, or `all` |
 | `attachments.enabled` | `true` | Download admitted RingCentral file/image attachments |
-| `attachments.maxCount` | `5` | Max attachments to process per inbound message |
-| `attachments.maxBytes` | `5242880` | Max bytes per downloaded attachment |
-| `debugInboundMessages` | `false` | Log detailed inbound message metadata (postId, parentPostId, threadId) |
+| `processingPlaceholder.enabled` | `false` | Show a placeholder while the agent is processing |
+| `debugInboundMessages` | `false` | Log inbound message metadata for troubleshooting |
 | `allowBots` | `false` | Allow bot-authored inbound messages |
-| `botExtensionId` | — | Override bot person ID (auto-detected if omitted) |
-| `textChunkLimit` | — | Max text length per message before chunking |
-| `historyMessageLimit` | `250` | Default history record count (max `1000`) |
-| `homeChannel` | — | Default history/home chat ID |
+| `botExtensionId` | auto-detected | Bot person ID for mention detection |
+| `historyMessageLimit` | `250` | Default history record count, max `1000` |
+| `homeChannel` | none | Default Home chat for history/artifact tools and owner confirmations |
 
-## RingCentral Setup
+### Legacy Migration Errors
 
-1. Create a RingCentral Bot Add-in app with Team Messaging and WebSocket Subscriptions permissions.
-2. Copy the bot static token into `botToken` or `RC_BOT_TOKEN`.
-3. Optionally create a JWT REST API app for the owner user with Team Messaging, WebSocket Subscriptions, Read Accounts, and Read Messages permissions.
-4. Put owner app credentials in `ownerCredentials` or `RC_USER_*`.
+These old access-control fields are rejected:
 
-## Agent Actions
-
-The shared OpenClaw `message` tool exposes these RingCentral actions when configured:
-
-| Action | Description |
+| Old | New |
 | --- | --- |
-| `send` | Send a message |
-| `read` | Read recent messages |
-| `edit` | Edit a message |
-| `delete` | Delete a message |
-| `channel-info` | Read chat metadata |
+| `allowedUserEmails` | `allowFrom` with stable person IDs |
+| `allowAllUsers` | `dmPolicy: "open"` plus `allowFrom: ["*"]` |
+| `allowedChannels` | `teams` |
+| `ignoredChannels` | omit the chat or set `teams.<id>.allow=false` |
+| `freeResponseChannels` | `teams.<id>.requireMention=false` |
+| `groups` | `teams` or `dm.groupChannels`, depending on RingCentral chat type |
+| `dm.policy` | `dmPolicy` |
+| `dm.allowFrom` | `allowFrom` |
 
-The optional `ringcentral_get_recent_messages` tool reads recent messages through owner credentials. Enable it explicitly with `tools.allow`.
+The corresponding legacy env vars (`RC_ALLOWED_USER_EMAILS`,
+`RC_ALLOW_ALL_USERS`, `RC_ALLOWED_CHANNELS`, `RC_IGNORED_CHANNELS`, and
+`RC_FREE_RESPONSE_CHANNELS`) are rejected with migration guidance.
 
-## Artifact Tools
-
-Optional artifact tools include Adaptive Cards, notes, and calendar events. Enable
-only the tools your RingCentral agent should use through `tools.allow`.
-
-`chat_id` selects the target chat. When omitted, tools fall back to
-`homeChannel`/`RC_HOME_CHANNEL`. For object-ID tools such as
-`ringcentral_get_note`, `ringcentral_update_note`,
-`ringcentral_get_calendar_event`, and `ringcentral_delete_adaptive_card`,
-`chat_id` is used only as the authorization context; the RingCentral API still
-operates on the object ID.
-
-When an artifact tool runs from a RingCentral group or team session and no
-explicit `chat_id`/`chatId`/`target` is provided, the plugin injects the current
-RingCentral chat ID before the tool call. Explicit targets always win. If the
-current session is not a RingCentral group/team session, the Home fallback above
-still applies.
-
-If the target chat is explicitly allowlisted with
-`teams.<chatId>.allow=true` or `dm.groupChannels.<chatId>.allow=true`, artifact
-tools use the bot token directly. The allowlist can come from config or the
-existing `RC_TEAMS` / `RC_GROUP_DM_CHANNELS` env fallbacks. `teams."*"` is only
-a defaults entry and does not authorize artifact writes or reads. Bot-token
-artifact failures are returned directly and do not fall back to owner
-credentials.
-
-For non-allowlisted targets, owner-backed note and calendar tools keep the
-existing Home behavior: Home chat operations run with owner credentials, and
-non-Home writes require `ringcentral_confirm_artifact_action` from the
-configured Home DM. Owner-backed reads outside Home are rejected. Adaptive Card
-tools remain bot-token tools and require either Home or an explicitly
-allowlisted target chat.
-
-## Verification
+### Local Verification
 
 ```bash
-pnpm test
+git diff --check
+node -e 'JSON.parse(require("fs").readFileSync("openclaw.plugin.json","utf8"))'
+pnpm test src/artifact-tools.test.ts --run
 pnpm typecheck
-```
-
-## Release
-
-Stable releases are published by pushing a `v*` tag. The release workflow
-validates that the tag matches `package.json`, runs typecheck and tests,
-publishes `openclaw-ringcentral` to npmjs with `NPM_TOKEN`, and creates a GitHub
-Release.
-
-Pushes to `main` also keep publishing beta builds to GitHub Packages through
-`publish-beta.yml`; those beta packages are separate from the stable npmjs
-release.
-
-## Live Smoke Test
-
-The GitHub Actions workflow `RingCentral Live Smoke` validates the real RingCentral API path without starting OpenClaw and without any LLM secrets.
-
-Configure the GitHub Environment `ringcentral-live` with these secrets:
-
-| Secret | Description |
-| --- | --- |
-| `RC_BOT_TOKEN` | Bot static token used to send and delete the test message |
-| `RC_USER_CLIENT_ID` | Owner JWT app client ID |
-| `RC_USER_CLIENT_SECRET` | Owner JWT app client secret |
-| `RC_USER_JWT_TOKEN` | Owner JWT token used to read recent history |
-| `RC_E2E_CHAT_ID` | Test chat/group ID |
-| `RC_SERVER_URL` | Optional API server URL, default `https://platform.ringcentral.com` |
-
-The workflow runs on PRs and `main`, and can also be run manually from GitHub
-Actions. It sends unique test messages, validates bot/owner reads, WebSocket
-receive, threaded replies, artifact APIs, and file/image upload handling. Test
-messages are retained by default for channel auditability; set `cleanup=true`
-for manual runs when cleanup is desired. File/image upload smoke is enabled by
-default and can be disabled manually with `file_upload=false`.
-
-Local live verification is also available:
-
-```bash
-RC_E2E_ENABLED=true \
-RC_BOT_TOKEN=... \
-RC_USER_CLIENT_ID=... \
-RC_USER_CLIENT_SECRET=... \
-RC_USER_JWT_TOKEN=... \
-RC_E2E_CHAT_ID=... \
-pnpm test:live:ringcentral
+pnpm build
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -335,11 +335,19 @@ only the tools your RingCentral agent should use through `tools.allow`.
 `chat_id` is used only as the authorization context; the RingCentral API still
 operates on the object ID.
 
+When an artifact tool runs from a RingCentral group or team session and no
+explicit `chat_id`/`chatId`/`target` is provided, the plugin injects the current
+RingCentral chat ID before the tool call. Explicit targets always win. If the
+current session is not a RingCentral group/team session, the Home fallback above
+still applies.
+
 If the target chat is explicitly allowlisted with
 `teams.<chatId>.allow=true` or `dm.groupChannels.<chatId>.allow=true`, artifact
-tools use the bot token directly. `teams."*"` is only a defaults entry and does
-not authorize artifact writes or reads. Bot-token artifact failures are returned
-directly and do not fall back to owner credentials.
+tools use the bot token directly. The allowlist can come from config or the
+existing `RC_TEAMS` / `RC_GROUP_DM_CHANNELS` env fallbacks. `teams."*"` is only
+a defaults entry and does not authorize artifact writes or reads. Bot-token
+artifact failures are returned directly and do not fall back to owner
+credentials.
 
 For non-allowlisted targets, owner-backed note and calendar tools keep the
 existing Home behavior: Home chat operations run with owner credentials, and

--- a/README.md
+++ b/README.md
@@ -323,6 +323,31 @@ The shared OpenClaw `message` tool exposes these RingCentral actions when config
 
 The optional `ringcentral_get_recent_messages` tool reads recent messages through owner credentials. Enable it explicitly with `tools.allow`.
 
+## Artifact Tools
+
+Optional artifact tools include Adaptive Cards, notes, and calendar events. Enable
+only the tools your RingCentral agent should use through `tools.allow`.
+
+`chat_id` selects the target chat. When omitted, tools fall back to
+`homeChannel`/`RC_HOME_CHANNEL`. For object-ID tools such as
+`ringcentral_get_note`, `ringcentral_update_note`,
+`ringcentral_get_calendar_event`, and `ringcentral_delete_adaptive_card`,
+`chat_id` is used only as the authorization context; the RingCentral API still
+operates on the object ID.
+
+If the target chat is explicitly allowlisted with
+`teams.<chatId>.allow=true` or `dm.groupChannels.<chatId>.allow=true`, artifact
+tools use the bot token directly. `teams."*"` is only a defaults entry and does
+not authorize artifact writes or reads. Bot-token artifact failures are returned
+directly and do not fall back to owner credentials.
+
+For non-allowlisted targets, owner-backed note and calendar tools keep the
+existing Home behavior: Home chat operations run with owner credentials, and
+non-Home writes require `ringcentral_confirm_artifact_action` from the
+configured Home DM. Owner-backed reads outside Home are rejected. Adaptive Card
+tools remain bot-token tools and require either Home or an explicitly
+allowlisted target chat.
+
 ## Verification
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { setRingCentralRuntime } from "./src/runtime.js";
 const plugin = {
   id: "openclaw-ringcentral",
   name: "RingCentral",
-  description: "OpenClaw RingCentral Team Messaging channel plugin",
+  description: "RingCentral Team Messaging for OpenClaw with DM, Team, Group DM, and artifact tools",
   configSchema: buildChannelConfigSchema(ringCentralConfigSchema),
   register(api: OpenClawPluginApi) {
     setRingCentralRuntime(api.runtime);

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 
+import { registerRingCentralArtifactToolHook } from "./src/artifact-tool-hook.js";
 import { ringcentralPlugin } from "./src/channel.js";
 import { ringCentralConfigSchema } from "./src/config-schema.js";
 import { setRingCentralRuntime } from "./src/runtime.js";
@@ -12,6 +13,7 @@ const plugin = {
   configSchema: buildChannelConfigSchema(ringCentralConfigSchema),
   register(api: OpenClawPluginApi) {
     setRingCentralRuntime(api.runtime);
+    registerRingCentralArtifactToolHook(api);
     api.registerChannel({ plugin: ringcentralPlugin });
   },
 };

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-ringcentral",
   "name": "RingCentral",
-  "description": "OpenClaw RingCentral Team Messaging channel plugin with allowlisted bot-token artifact tools",
+  "description": "RingCentral Team Messaging for OpenClaw with DM, Team, Group DM, and artifact tools",
   "channels": [
     "ringcentral"
   ],
@@ -97,6 +97,7 @@
     },
     "ownerCredentials": {
       "label": "Owner Credentials (optional)",
+      "help": "Optional owner JWT credentials for recent history and Home-confirmed note/calendar operations.",
       "advanced": true
     },
     "ownerCredentials.clientId": {
@@ -160,6 +161,7 @@
     },
     "homeChannel": {
       "label": "Home Channel",
+      "help": "Default Home chat for history/artifact tools and owner confirmation flows.",
       "advanced": true
     },
     "homeChannelName": {
@@ -173,7 +175,7 @@
     },
     "groupPolicy": {
       "label": "Team Policy",
-      "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Team messages are mention-gated by default."
+      "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Explicit Team allowlists can authorize artifact bot-token tools."
     },
     "requireMention": {
       "label": "Require @Mention (Global)",
@@ -206,15 +208,15 @@
     },
     "actions.events": {
       "label": "Events",
-      "help": "Calendar event tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
+      "help": "Calendar event tools. Explicit or current allowlisted chats use the bot token directly; non-allowlisted owner-backed writes keep Home confirmation."
     },
     "actions.notes": {
       "label": "Notes",
-      "help": "Note tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
+      "help": "Note tools. Explicit or current allowlisted chats use the bot token directly; non-allowlisted owner-backed writes keep Home confirmation."
     },
     "actions.adaptiveCards": {
       "label": "Adaptive Cards",
-      "help": "Adaptive Card tools use the bot token in Home or explicitly allowlisted chats."
+      "help": "Adaptive Card tools use the bot token in Home or explicit/current allowlisted chats."
     },
     "dmPolicy": {
       "label": "DM Policy",
@@ -231,7 +233,7 @@
     },
     "teams": {
       "label": "Allowed Teams",
-      "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults."
+      "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults; it is not an artifact allowlist entry."
     },
     "teams.*": {
       "label": "Team Configuration"
@@ -252,12 +254,12 @@
     },
     "dm.groupEnabled": {
       "label": "Enable Group DMs",
-      "help": "Allow explicitly configured RingCentral Group conversations.",
+      "help": "Enable only explicitly configured RingCentral Group DM conversations.",
       "advanced": true
     },
     "dm.groupChannels": {
       "label": "Allowed Group DMs",
-      "help": "RingCentral Group conversation configurations keyed by chat ID.",
+      "help": "Explicit RingCentral Group DM configurations keyed by chat ID; allowlisted entries can authorize artifact bot-token tools.",
       "advanced": true
     },
     "dm.groupChannels.*": {
@@ -536,7 +538,7 @@
   "channelConfigs": {
     "ringcentral": {
       "label": "RingCentral",
-      "description": "OpenClaw RingCentral Team Messaging channel plugin",
+      "description": "RingCentral Team Messaging for OpenClaw with DM, Team, Group DM, and artifact tools",
       "recommendedAgent": {
         "id": "ringcentral-bot",
         "model": null,
@@ -821,6 +823,7 @@
         },
         "ownerCredentials": {
           "label": "Owner Credentials (optional)",
+          "help": "Optional owner JWT credentials for recent history and Home-confirmed note/calendar operations.",
           "advanced": true
         },
         "ownerCredentials.clientId": {
@@ -884,6 +887,7 @@
         },
         "homeChannel": {
           "label": "Home Channel",
+          "help": "Default Home chat for history/artifact tools and owner confirmation flows.",
           "advanced": true
         },
         "homeChannelName": {
@@ -897,7 +901,7 @@
         },
         "groupPolicy": {
           "label": "Team Policy",
-          "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Team messages are mention-gated by default."
+          "help": "Controls RingCentral Team/Everyone chats: disabled, allowlist, or open. Explicit Team allowlists can authorize artifact bot-token tools."
         },
         "requireMention": {
           "label": "Require @Mention (Global)",
@@ -930,15 +934,15 @@
         },
         "actions.events": {
           "label": "Events",
-          "help": "Calendar event tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
+          "help": "Calendar event tools. Explicit or current allowlisted chats use the bot token directly; non-allowlisted owner-backed writes keep Home confirmation."
         },
         "actions.notes": {
           "label": "Notes",
-          "help": "Note tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
+          "help": "Note tools. Explicit or current allowlisted chats use the bot token directly; non-allowlisted owner-backed writes keep Home confirmation."
         },
         "actions.adaptiveCards": {
           "label": "Adaptive Cards",
-          "help": "Adaptive Card tools use the bot token in Home or explicitly allowlisted chats."
+          "help": "Adaptive Card tools use the bot token in Home or explicit/current allowlisted chats."
         },
         "dmPolicy": {
           "label": "DM Policy",
@@ -955,7 +959,7 @@
         },
         "teams": {
           "label": "Allowed Teams",
-          "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults."
+          "help": "RingCentral Team/Everyone chat configurations keyed by chat ID. Use \"*\" only for defaults; it is not an artifact allowlist entry."
         },
         "teams.*": {
           "label": "Team Configuration"
@@ -976,12 +980,12 @@
         },
         "dm.groupEnabled": {
           "label": "Enable Group DMs",
-          "help": "Allow explicitly configured RingCentral Group conversations.",
+          "help": "Enable only explicitly configured RingCentral Group DM conversations.",
           "advanced": true
         },
         "dm.groupChannels": {
           "label": "Allowed Group DMs",
-          "help": "RingCentral Group conversation configurations keyed by chat ID.",
+          "help": "Explicit RingCentral Group DM configurations keyed by chat ID; allowlisted entries can authorize artifact bot-token tools.",
           "advanced": true
         },
         "dm.groupChannels.*": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-ringcentral",
   "name": "RingCentral",
-  "description": "OpenClaw RingCentral Team Messaging channel plugin",
+  "description": "OpenClaw RingCentral Team Messaging channel plugin with allowlisted bot-token artifact tools",
   "channels": [
     "ringcentral"
   ],
@@ -202,13 +202,16 @@
       "label": "Tasks"
     },
     "actions.events": {
-      "label": "Events"
+      "label": "Events",
+      "help": "Calendar event tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
     },
     "actions.notes": {
-      "label": "Notes"
+      "label": "Notes",
+      "help": "Note tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
     },
     "actions.adaptiveCards": {
-      "label": "Adaptive Cards"
+      "label": "Adaptive Cards",
+      "help": "Adaptive Card tools use the bot token in Home or explicitly allowlisted chats."
     },
     "dmPolicy": {
       "label": "DM Policy",
@@ -923,13 +926,16 @@
           "label": "Tasks"
         },
         "actions.events": {
-          "label": "Events"
+          "label": "Events",
+          "help": "Calendar event tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
         },
         "actions.notes": {
-          "label": "Notes"
+          "label": "Notes",
+          "help": "Note tools. Explicitly allowlisted chats use the bot token directly; other owner-backed writes keep Home confirmation."
         },
         "actions.adaptiveCards": {
-          "label": "Adaptive Cards"
+          "label": "Adaptive Cards",
+          "help": "Adaptive Card tools use the bot token in Home or explicitly allowlisted chats."
         },
         "dmPolicy": {
           "label": "DM Policy",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5,6 +5,9 @@
   "channels": [
     "ringcentral"
   ],
+  "hooks": [
+    "before_tool_call"
+  ],
   "contracts": {
     "tools": [
       "ringcentral_get_recent_messages",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "description": "OpenClaw RingCentral Team Messaging channel plugin",
+  "description": "RingCentral Team Messaging for OpenClaw with DM, Team, Group DM, and artifact tools",
   "license": "MIT",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/src/artifact-tool-hook.test.ts
+++ b/src/artifact-tool-hook.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { injectRingCentralArtifactToolChatId } from "./artifact-tool-hook.js";
+
+describe("RingCentral artifact tool hook", () => {
+  it("injects the current RingCentral group chat as chat_id for artifact tools without a target", () => {
+    const result = injectRingCentralArtifactToolChatId(
+      {
+        toolName: "ringcentral_create_note",
+        params: { title: "Note" },
+      },
+      {
+        sessionKey: "agent:main:ringcentral:channel:team-1",
+        channelId: "team-1",
+      },
+    );
+
+    expect(result).toEqual({
+      params: {
+        title: "Note",
+        chat_id: "team-1",
+      },
+    });
+  });
+
+  it("preserves explicit artifact targets", () => {
+    const result = injectRingCentralArtifactToolChatId(
+      {
+        toolName: "ringcentral_create_note",
+        params: { chat_id: "explicit-team", title: "Note" },
+      },
+      {
+        sessionKey: "agent:main:ringcentral:channel:team-1",
+        channelId: "team-1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("does not inject for non-artifact RingCentral tools", () => {
+    const result = injectRingCentralArtifactToolChatId(
+      {
+        toolName: "ringcentral_get_recent_messages",
+        params: {},
+      },
+      {
+        sessionKey: "agent:main:ringcentral:channel:team-1",
+        channelId: "team-1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("does not inject for non-RingCentral sessions", () => {
+    const result = injectRingCentralArtifactToolChatId(
+      {
+        toolName: "ringcentral_create_note",
+        params: { title: "Note" },
+      },
+      {
+        sessionKey: "agent:main:slack:channel:C123",
+        channelId: "C123",
+      },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("does not inject confirmation targets", () => {
+    const result = injectRingCentralArtifactToolChatId(
+      {
+        toolName: "ringcentral_confirm_artifact_action",
+        params: { confirmation_id: "confirm-1" },
+      },
+      {
+        sessionKey: "agent:main:ringcentral:channel:team-1",
+        channelId: "team-1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/artifact-tool-hook.ts
+++ b/src/artifact-tool-hook.ts
@@ -1,0 +1,83 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { RINGCENTRAL_ARTIFACT_TOOL_NAMES } from "./artifact-tools.js";
+
+type BeforeToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+};
+
+type BeforeToolCallContext = {
+  sessionKey?: string;
+  channelId?: string;
+};
+
+const AUTO_TARGET_TOOL_NAMES: Set<string> = new Set(
+  RINGCENTRAL_ARTIFACT_TOOL_NAMES.filter((name) => name !== "ringcentral_confirm_artifact_action"),
+);
+
+const RINGCENTRAL_GROUP_SESSION_MARKERS = [
+  ":ringcentral:channel:",
+  ":ringcentral:group:",
+  "ringcentral:channel:",
+  "ringcentral:group:",
+];
+
+export function registerRingCentralArtifactToolHook(api: OpenClawPluginApi): void {
+  api.on("before_tool_call", (event, ctx) => injectRingCentralArtifactToolChatId(event, ctx));
+}
+
+export function injectRingCentralArtifactToolChatId(
+  event: BeforeToolCallEvent,
+  ctx: BeforeToolCallContext,
+): { params: Record<string, unknown> } | void {
+  if (!AUTO_TARGET_TOOL_NAMES.has(event.toolName)) {
+    return;
+  }
+  if (hasExplicitArtifactTarget(event.params)) {
+    return;
+  }
+  const chatId = resolveRingCentralSessionChatId(ctx);
+  if (!chatId) {
+    return;
+  }
+  return {
+    params: {
+      ...event.params,
+      chat_id: chatId,
+    },
+  };
+}
+
+function hasExplicitArtifactTarget(params: Record<string, unknown>): boolean {
+  return (
+    readString(params.chat_id) !== undefined ||
+    readString(params.chatId) !== undefined ||
+    readString(params.target) !== undefined
+  );
+}
+
+function resolveRingCentralSessionChatId(ctx: BeforeToolCallContext): string | undefined {
+  const fromSession = readRingCentralGroupOrChannelSessionId(ctx.sessionKey);
+  if (!fromSession) return undefined;
+  const channelId = readString(ctx.channelId);
+  return channelId && channelId !== "ringcentral" ? channelId : fromSession;
+}
+
+function readRingCentralGroupOrChannelSessionId(sessionKey: unknown): string | undefined {
+  const raw = readString(sessionKey);
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  for (const marker of RINGCENTRAL_GROUP_SESSION_MARKERS) {
+    const markerIndex = lower.indexOf(marker);
+    if (markerIndex === -1) continue;
+    const start = markerIndex + marker.length;
+    const rawId = raw.slice(start);
+    const threadIndex = rawId.toLowerCase().lastIndexOf(":thread:");
+    return (threadIndex === -1 ? rawId : rawId.slice(0, threadIndex)).trim() || undefined;
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/artifact-tools.test.ts
+++ b/src/artifact-tools.test.ts
@@ -34,6 +34,27 @@ const cfg = {
   },
 };
 
+const allowlistedCfg = {
+  channels: {
+    ringcentral: {
+      ...cfg.channels.ringcentral,
+      teams: {
+        "team-1": { allow: true },
+      },
+      dm: {
+        groupEnabled: true,
+        groupChannels: {
+          "group-dm-1": { allow: true },
+        },
+      },
+    },
+  },
+};
+
+function findTool(config: unknown, name: string) {
+  return createRingCentralArtifactTools(config).find((candidate) => candidate.name === name)!;
+}
+
 beforeEach(() => {
   mockFetch.mockReset();
   __testing.pendingConfirmations.clear();
@@ -66,24 +87,137 @@ describe("RingCentral artifact tools", () => {
     }
   });
 
-  it("rejects Adaptive Card writes outside the configured Home chat", async () => {
-    const tool = createRingCentralArtifactTools(cfg).find(
-      (candidate) => candidate.name === "ringcentral_create_adaptive_card",
-    )!;
+  it("creates an Adaptive Card in the configured Home chat with the bot token", async () => {
+    const tool = findTool(cfg, "ringcentral_create_adaptive_card");
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "card-home", type: "AdaptiveCard" }));
+
+    const result = await tool.execute("call-1", { text: "hello" } as any);
+
+    expect(result.details).toMatchObject({ success: true, card_id: "card-home" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/home-dm/adaptive-cards",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }),
+    );
+  });
+
+  it("uses the bot token directly for allowlisted team artifact tools", async () => {
+    const run = (name: string, args: Record<string, unknown>) =>
+      findTool(allowlistedCfg, name).execute("call-1", args as any);
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ id: "card-1", type: "AdaptiveCard" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "card-1", type: "AdaptiveCard" }))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({ records: [{ id: "note-1", title: "Note" }] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-2", title: "Note" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-2", title: "Note" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-2", title: "Updated" }))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({ records: [{ id: "event-1", title: "Event" }] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "event-2", title: "Event" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "event-2", title: "Event" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "event-2", title: "Updated" }))
+      .mockResolvedValueOnce(jsonResponse({}));
+
+    await run("ringcentral_create_adaptive_card", { chat_id: "team-1", text: "card" });
+    await run("ringcentral_update_adaptive_card", { chat_id: "team-1", card_id: "card-1", text: "card" });
+    await run("ringcentral_delete_adaptive_card", { chat_id: "team-1", card_id: "card-1" });
+    await run("ringcentral_list_notes", { chat_id: "team-1" });
+    await run("ringcentral_create_note", { chat_id: "team-1", title: "Note" });
+    await run("ringcentral_get_note", { chat_id: "team-1", note_id: "note-2" });
+    await run("ringcentral_update_note", { chat_id: "team-1", note_id: "note-2", title: "Updated" });
+    await run("ringcentral_delete_note", { chat_id: "team-1", note_id: "note-2" });
+    await run("ringcentral_publish_note", { chat_id: "team-1", note_id: "note-2" });
+    await run("ringcentral_list_calendar_events", { chat_id: "team-1" });
+    await run("ringcentral_create_calendar_event", {
+      chat_id: "team-1",
+      title: "Event",
+      start_time: "2026-06-04T10:00:00Z",
+      end_time: "2026-06-04T11:00:00Z",
+    });
+    await run("ringcentral_get_calendar_event", { chat_id: "team-1", event_id: "event-2" });
+    await run("ringcentral_update_calendar_event", {
+      chat_id: "team-1",
+      event_id: "event-2",
+      title: "Updated",
+      start_time: "2026-06-04T10:00:00Z",
+      end_time: "2026-06-04T11:00:00Z",
+    });
+    await run("ringcentral_delete_calendar_event", { chat_id: "team-1", event_id: "event-2" });
+
+    const calls = mockFetch.mock.calls;
+    expect(calls).toHaveLength(14);
+    expect(calls.map(([url]) => String(url))).not.toContain("https://api.example.com/restapi/oauth/token");
+    for (const [, init] of calls) {
+      expect(init).toEqual(expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }));
+    }
+  });
+
+  it("uses the bot token directly for allowlisted group DM artifact tools", async () => {
+    const tool = findTool(allowlistedCfg, "ringcentral_create_note");
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "note-group-dm", title: "Note" }));
+
+    const result = await tool.execute("call-1", {
+      chat_id: "group-dm-1",
+      title: "Group DM Note",
+    } as any);
+
+    expect(result.details).toMatchObject({ success: true, note_id: "note-group-dm" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/group-dm-1/notes",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }),
+    );
+  });
+
+  it("does not fall back to owner credentials when the allowlisted bot token path fails", async () => {
+    const tool = findTool(allowlistedCfg, "ringcentral_create_note");
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "forbidden" }, 403));
+
+    const result = await tool.execute("call-1", {
+      chat_id: "team-1",
+      title: "Team Note",
+    } as any);
+
+    expect(result.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("bot token"),
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(String(mockFetch.mock.calls[0]?.[0])).not.toContain("/oauth/token");
+  });
+
+  it("does not treat teams wildcard defaults as artifact allowlist entries", async () => {
+    const wildcardCfg = {
+      channels: {
+        ringcentral: {
+          ...cfg.channels.ringcentral,
+          teams: {
+            "*": { allow: true },
+          },
+        },
+      },
+    };
+    const tool = findTool(wildcardCfg, "ringcentral_create_adaptive_card");
 
     const result = await tool.execute("call-1", { chat_id: "team-1", text: "hello" } as any);
 
     expect(result.details).toMatchObject({
       success: false,
-      error: expect.stringContaining("Home chat"),
+      error: expect.stringContaining("allowlisted"),
     });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("creates an owner note directly in Home chat", async () => {
-    const tool = createRingCentralArtifactTools(cfg).find(
-      (candidate) => candidate.name === "ringcentral_create_note",
-    )!;
+    const tool = findTool(cfg, "ringcentral_create_note");
     mockFetch
       .mockResolvedValueOnce(jsonResponse({ access_token: "owner-access", expires_in: 3600 }))
       .mockResolvedValueOnce(jsonResponse({ id: "note-1", title: "Note" }));
@@ -181,6 +315,26 @@ describe("RingCentral artifact tools", () => {
     expect(result.details).toMatchObject({
       success: false,
       error: expect.stringContaining("homeChannel"),
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("requires chat_id or homeChannel for object-id artifact tools", async () => {
+    const noHomeCfg = {
+      channels: {
+        ringcentral: {
+          botToken: "bot-token",
+          server: "https://api.example.com",
+        },
+      },
+    };
+    const tool = findTool(noHomeCfg, "ringcentral_get_note");
+
+    const result = await tool.execute("call-1", { note_id: "note-1" } as any);
+
+    expect(result.details).toMatchObject({
+      success: false,
+      error: expect.stringContaining("chat_id"),
     });
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/src/artifact-tools.test.ts
+++ b/src/artifact-tools.test.ts
@@ -5,6 +5,7 @@ import {
   createRingCentralArtifactTools,
   RINGCENTRAL_ARTIFACT_TOOL_NAMES,
 } from "./artifact-tools.js";
+import { __setRingCentralRuntimeForTest } from "./runtime.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -58,6 +59,8 @@ function findTool(config: unknown, name: string) {
 beforeEach(() => {
   mockFetch.mockReset();
   __testing.pendingConfirmations.clear();
+  __setRingCentralRuntimeForTest(null);
+  vi.unstubAllEnvs();
 });
 
 describe("RingCentral artifact tools", () => {
@@ -85,6 +88,7 @@ describe("RingCentral artifact tools", () => {
       expect(manifest.contracts.tools).toContain(toolName);
       expect(manifest.toolMetadata[toolName]).toEqual({ optional: true });
     }
+    expect(manifest.hooks).toContain("before_tool_call");
   });
 
   it("creates an Adaptive Card in the configured Home chat with the bot token", async () => {
@@ -173,6 +177,66 @@ describe("RingCentral artifact tools", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }),
+    );
+  });
+
+  it("resolves JSON allowlists from runtime full config when channel tools receive agent config", async () => {
+    __setRingCentralRuntimeForTest({
+      config: {
+        current: () => allowlistedCfg,
+      },
+    } as any);
+    const agentCfg = { tools: { allow: ["ringcentral_create_adaptive_card"] } };
+    const tool = findTool(agentCfg, "ringcentral_create_adaptive_card");
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "card-runtime", type: "AdaptiveCard" }));
+
+    const result = await tool.execute("call-1", { chat_id: "team-1", text: "runtime" } as any);
+
+    expect(result.details).toMatchObject({ success: true, card_id: "card-runtime" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/team-1/adaptive-cards",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer bot-token" }),
+      }),
+    );
+  });
+
+  it("resolves artifact allowlists from existing RC_TEAMS and RC_GROUP_DM_CHANNELS env fallbacks", async () => {
+    vi.stubEnv("RC_BOT_TOKEN", "env-bot-token");
+    vi.stubEnv("RC_SERVER_URL", "https://api.example.com");
+    vi.stubEnv("RC_TEAMS", JSON.stringify({ "env-team": { allow: true } }));
+    vi.stubEnv("RC_GROUP_DM_CHANNELS", JSON.stringify({ "env-group-dm": { allow: true } }));
+    const tools = createRingCentralArtifactTools({ tools: { allow: ["ringcentral_create_note"] } });
+    const createNote = tools.find((candidate) => candidate.name === "ringcentral_create_note")!;
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ id: "note-env-team", title: "Team" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "note-env-group-dm", title: "Group DM" }));
+
+    const teamResult = await createNote.execute("call-1", {
+      chat_id: "env-team",
+      title: "Team Note",
+    } as any);
+    const groupResult = await createNote.execute("call-2", {
+      chat_id: "env-group-dm",
+      title: "Group DM Note",
+    } as any);
+
+    expect(teamResult.details).toMatchObject({ success: true, note_id: "note-env-team" });
+    expect(groupResult.details).toMatchObject({ success: true, note_id: "note-env-group-dm" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/env-team/notes",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer env-bot-token" }),
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/team-messaging/v1/chats/env-group-dm/notes",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer env-bot-token" }),
       }),
     );
   });

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -2,10 +2,17 @@ import { randomBytes } from "node:crypto";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { ChannelAgentTool } from "openclaw/plugin-sdk/channel-contract";
 import { Type } from "typebox";
-import { getRcConfig, hasOwnerCredentials, resolveAccount } from "./accounts.js";
+import { hasOwnerCredentials, resolveAccount } from "./accounts.js";
 import { createBotClient, createOwnerClient, type RingCentralClient } from "./client.js";
+import { tryGetRingCentralRuntime } from "./runtime.js";
 import { extractChatId } from "./targets.js";
-import type { CreateAdaptiveCardRequest, CreateEventRequest, CreateNoteRequest, ResolvedAccount } from "./types.js";
+import type {
+  CreateAdaptiveCardRequest,
+  CreateEventRequest,
+  CreateNoteRequest,
+  ResolvedAccount,
+  RingCentralConfig,
+} from "./types.js";
 
 type ArtifactPendingAction =
   | {
@@ -647,7 +654,7 @@ function cleanExpiredPendingConfirmations(): void {
 }
 
 function resolveArtifactAccount(cfg: unknown) {
-  return resolveAccount(getRcConfig(cfg ?? {}));
+  return resolveAccount(resolveArtifactChannelConfig(cfg));
 }
 
 function resolveArtifactTarget(cfg: unknown, params: Record<string, unknown>): {
@@ -704,6 +711,47 @@ function formatError(err: unknown): string {
 
 function resolveToolChatId(params: Record<string, unknown>, fallback?: string): string | undefined {
   return readChatId(params.chat_id ?? params.chatId ?? params.target) ?? fallback;
+}
+
+function resolveArtifactChannelConfig(cfg: unknown): RingCentralConfig {
+  const localConfig = readRingCentralChannelConfig(cfg);
+  if (localConfig) return localConfig;
+  const runtime = tryGetRingCentralRuntime();
+  if (!runtime) return {};
+  try {
+    return readRingCentralChannelConfig(runtime.config.current()) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function readRingCentralChannelConfig(cfg: unknown): RingCentralConfig | undefined {
+  if (!isRecord(cfg)) return undefined;
+  const channels = cfg.channels;
+  if (isRecord(channels) && Object.prototype.hasOwnProperty.call(channels, "ringcentral")) {
+    return (channels.ringcentral ?? {}) as RingCentralConfig;
+  }
+  if (looksLikeRingCentralChannelConfig(cfg)) {
+    return cfg as RingCentralConfig;
+  }
+  return undefined;
+}
+
+function looksLikeRingCentralChannelConfig(value: Record<string, unknown>): boolean {
+  return [
+    "botToken",
+    "ownerCredentials",
+    "credentials",
+    "server",
+    "botExtensionId",
+    "dmPolicy",
+    "allowFrom",
+    "groupPolicy",
+    "teams",
+    "dm",
+    "homeChannel",
+    "homeChannelName",
+  ].some((key) => Object.prototype.hasOwnProperty.call(value, key));
 }
 
 function readChatId(value: unknown): string | undefined {

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -5,7 +5,7 @@ import { Type } from "typebox";
 import { getRcConfig, hasOwnerCredentials, resolveAccount } from "./accounts.js";
 import { createBotClient, createOwnerClient, type RingCentralClient } from "./client.js";
 import { extractChatId } from "./targets.js";
-import type { CreateAdaptiveCardRequest, CreateEventRequest, CreateNoteRequest } from "./types.js";
+import type { CreateAdaptiveCardRequest, CreateEventRequest, CreateNoteRequest, ResolvedAccount } from "./types.js";
 
 type ArtifactPendingAction =
   | {
@@ -124,7 +124,7 @@ function createAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_create_adaptive_card",
     label: "Create RingCentral Adaptive Card",
-    description: "Create an Adaptive Card in the configured RingCentral Home chat using the bot token.",
+    description: "Create an Adaptive Card in the configured RingCentral Home chat or an allowlisted chat using the bot token.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       card: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
@@ -146,16 +146,17 @@ function getAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
     label: "Get RingCentral Adaptive Card",
     description: "Read a RingCentral Adaptive Card by card ID using the bot token.",
     parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
       card_id: Type.String(),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
       const cardId = readString(params.card_id);
       if (!cardId) return errorResult("card_id is required.");
-      const account = resolveArtifactAccount(cfg);
-      const client = createBotClient(account.server, account.botToken);
-      const card = await client.getAdaptiveCard(cardId);
-      return okResult({ success: true, card });
+      return runBotCardTool(cfg, params, async (client) => {
+        const card = await client.getAdaptiveCard(cardId);
+        return okResult({ success: true, card });
+      });
     },
   };
 }
@@ -164,7 +165,7 @@ function updateAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_update_adaptive_card",
     label: "Update RingCentral Adaptive Card",
-    description: "Replace an Adaptive Card from the configured RingCentral Home chat using the bot token.",
+    description: "Replace an Adaptive Card from the configured RingCentral Home chat or an allowlisted chat using the bot token.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       card_id: Type.String(),
@@ -189,16 +190,17 @@ function deleteAdaptiveCardTool(cfg?: unknown): ChannelAgentTool {
     label: "Delete RingCentral Adaptive Card",
     description: "Delete an Adaptive Card by card ID using the bot token.",
     parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
       card_id: Type.String(),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
       const cardId = readString(params.card_id);
       if (!cardId) return errorResult("card_id is required.");
-      const account = resolveArtifactAccount(cfg);
-      const client = createBotClient(account.server, account.botToken);
-      await client.deleteAdaptiveCard(cardId);
-      return okResult({ success: true, deleted: true });
+      return runBotCardTool(cfg, params, async (client) => {
+        await client.deleteAdaptiveCard(cardId);
+        return okResult({ success: true, deleted: true });
+      });
     },
   };
 }
@@ -207,14 +209,14 @@ function listNotesTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_list_notes",
     label: "List RingCentral Notes",
-    description: "List notes in the configured RingCentral Home chat using owner credentials.",
+    description: "List notes in the configured RingCentral Home chat using owner credentials or an allowlisted chat using the bot token.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       record_count: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
-      return runOwnerReadTool(cfg, params, async (client, chatId) => {
+      return runArtifactReadTool(cfg, params, async (client, chatId) => {
         const result = await client.listNotes(chatId);
         return okResult({
           success: true,
@@ -230,7 +232,7 @@ function createNoteTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_create_note",
     label: "Create RingCentral Note",
-    description: "Create a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    description: "Create a RingCentral note. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       title: Type.String(),
@@ -256,17 +258,19 @@ function getNoteTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_get_note",
     label: "Get RingCentral Note",
-    description: "Read a RingCentral note by note ID using owner credentials.",
+    description: "Read a RingCentral note by note ID using owner credentials or an allowlisted chat using the bot token.",
     parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
       note_id: Type.String(),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
       const noteId = readString(params.note_id);
       if (!noteId) return errorResult("note_id is required.");
-      const client = createOwnerArtifactClient(cfg);
-      const note = await client.getNote(noteId);
-      return okResult({ success: true, note });
+      return runArtifactReadTool(cfg, params, async (client) => {
+        const note = await client.getNote(noteId);
+        return okResult({ success: true, note });
+      });
     },
   };
 }
@@ -275,7 +279,7 @@ function updateNoteTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_update_note",
     label: "Update RingCentral Note",
-    description: "Update a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    description: "Update a RingCentral note. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       note_id: Type.String(),
@@ -305,7 +309,7 @@ function deleteNoteTool(cfg?: unknown): ChannelAgentTool {
     cfg,
     name: "ringcentral_delete_note",
     label: "Delete RingCentral Note",
-    description: "Delete a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    description: "Delete a RingCentral note. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     kind: "delete-note",
     summaryVerb: "delete",
   });
@@ -316,7 +320,7 @@ function publishNoteTool(cfg?: unknown): ChannelAgentTool {
     cfg,
     name: "ringcentral_publish_note",
     label: "Publish RingCentral Note",
-    description: "Publish a RingCentral note. Non-Home chat writes require Home DM confirmation.",
+    description: "Publish a RingCentral note. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     kind: "publish-note",
     summaryVerb: "publish",
   });
@@ -356,14 +360,14 @@ function listEventsTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_list_calendar_events",
     label: "List RingCentral Calendar Events",
-    description: "List calendar events in the configured RingCentral Home chat using owner credentials.",
+    description: "List calendar events in the configured RingCentral Home chat using owner credentials or an allowlisted chat using the bot token.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       record_count: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
-      return runOwnerReadTool(cfg, params, async (client, chatId) => {
+      return runArtifactReadTool(cfg, params, async (client, chatId) => {
         const result = await client.listEvents(chatId, clampCount(params.record_count, 50, 1, 100));
         return okResult({
           success: true,
@@ -379,7 +383,7 @@ function createEventTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_create_calendar_event",
     label: "Create RingCentral Calendar Event",
-    description: "Create a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    description: "Create a RingCentral calendar event. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       title: Type.String(),
@@ -409,17 +413,19 @@ function getEventTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_get_calendar_event",
     label: "Get RingCentral Calendar Event",
-    description: "Read a RingCentral calendar event by event ID using owner credentials.",
+    description: "Read a RingCentral calendar event by event ID using owner credentials or an allowlisted chat using the bot token.",
     parameters: Type.Object({
+      chat_id: Type.Optional(Type.String()),
       event_id: Type.String(),
     }),
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
       const eventId = readString(params.event_id);
       if (!eventId) return errorResult("event_id is required.");
-      const client = createOwnerArtifactClient(cfg);
-      const event = await client.getEvent(eventId);
-      return okResult({ success: true, event });
+      return runArtifactReadTool(cfg, params, async (client) => {
+        const event = await client.getEvent(eventId);
+        return okResult({ success: true, event });
+      });
     },
   };
 }
@@ -428,7 +434,7 @@ function updateEventTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_update_calendar_event",
     label: "Update RingCentral Calendar Event",
-    description: "Update a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    description: "Update a RingCentral calendar event. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       event_id: Type.String(),
@@ -461,7 +467,7 @@ function deleteEventTool(cfg?: unknown): ChannelAgentTool {
   return {
     name: "ringcentral_delete_calendar_event",
     label: "Delete RingCentral Calendar Event",
-    description: "Delete a RingCentral calendar event. Non-Home chat writes require Home DM confirmation.",
+    description: "Delete a RingCentral calendar event. Allowlisted chats use the bot token; other non-Home writes require Home DM confirmation.",
     parameters: Type.Object({
       chat_id: Type.Optional(Type.String()),
       event_id: Type.String(),
@@ -485,35 +491,35 @@ async function runBotCardTool(
   params: Record<string, unknown>,
   fn: (client: RingCentralClient, chatId: string) => Promise<AgentToolResult<unknown>>,
 ): Promise<AgentToolResult<unknown>> {
-  const account = resolveArtifactAccount(cfg);
-  const chatId = resolveToolChatId(params, account.homeChannel);
-  if (!chatId) {
+  const target = resolveArtifactTarget(cfg, params);
+  if (!target.chatId) {
     return errorResult("chat_id is required unless RC_HOME_CHANNEL/homeChannel is configured.");
   }
-  if (account.homeChannel && chatId !== account.homeChannel) {
-    return errorResult("RingCentral Adaptive Card tools can only target the configured Home chat.");
+  if (!target.isHome && !target.isAllowlisted) {
+    return errorResult("RingCentral bot artifact tools can only target the configured Home chat or explicitly allowlisted chats.");
   }
-  const client = createBotClient(account.server, account.botToken);
-  return fn(client, chatId);
+  return runBotArtifactAction(target.account, (client) => fn(client, target.chatId));
 }
 
-async function runOwnerReadTool(
+async function runArtifactReadTool(
   cfg: unknown,
   params: Record<string, unknown>,
   fn: (client: RingCentralClient, chatId: string) => Promise<AgentToolResult<unknown>>,
 ): Promise<AgentToolResult<unknown>> {
-  const account = resolveArtifactAccount(cfg);
-  if (!hasOwnerCredentials(account)) {
-    return errorResult("RingCentral owner credentials are not configured.");
-  }
-  const chatId = resolveToolChatId(params, account.homeChannel);
-  if (!chatId) {
+  const target = resolveArtifactTarget(cfg, params);
+  if (!target.chatId) {
     return errorResult("chat_id is required unless RC_HOME_CHANNEL/homeChannel is configured.");
   }
-  if (account.homeChannel && chatId !== account.homeChannel) {
-    return errorResult("RingCentral owner artifact reads can only target the configured Home chat.");
+  if (target.isAllowlisted) {
+    return runBotArtifactAction(target.account, (client) => fn(client, target.chatId));
   }
-  return fn(createOwnerArtifactClient(cfg), chatId);
+  if (!target.isHome) {
+    return errorResult("RingCentral owner artifact reads can only target the configured Home chat or explicitly allowlisted chats.");
+  }
+  if (!hasOwnerCredentials(target.account)) {
+    return errorResult("RingCentral owner credentials are not configured.");
+  }
+  return fn(createOwnerArtifactClientFromAccount(target.account), target.chatId);
 }
 
 async function runOwnerWriteTool(
@@ -522,30 +528,32 @@ async function runOwnerWriteTool(
   action: ArtifactPendingAction,
   summary: string,
 ): Promise<AgentToolResult<unknown>> {
-  const account = resolveArtifactAccount(cfg);
-  if (!hasOwnerCredentials(account)) {
+  const target = resolveArtifactTarget(cfg, params);
+  if (!target.chatId) {
+    return errorResult("chat_id is required unless RC_HOME_CHANNEL/homeChannel is configured.");
+  }
+  const scopedAction = { ...action, chatId: target.chatId } as ArtifactPendingAction;
+  if (target.isAllowlisted) {
+    return runBotArtifactAction(target.account, (client) => executePendingAction(client, scopedAction));
+  }
+  if (!hasOwnerCredentials(target.account)) {
     return errorResult("RingCentral owner credentials are not configured.");
   }
-  if (!account.homeChannel) {
+  if (!target.account.homeChannel) {
     return errorResult("RC_HOME_CHANNEL/homeChannel must be configured before owner-backed artifact writes.");
   }
-  const chatId = resolveToolChatId(params, account.homeChannel);
-  if (!chatId) {
-    return errorResult("chat_id is required.");
-  }
-  const scopedAction = { ...action, chatId } as ArtifactPendingAction;
-  if (chatId !== account.homeChannel) {
+  if (!target.isHome) {
     const confirmationId = createPendingConfirmation(scopedAction, summary);
     return okResult({
       success: false,
       requiresConfirmation: true,
       confirmation_id: confirmationId,
       summary,
-      target_chat_id: chatId,
+      target_chat_id: target.chatId,
       instruction: "Call ringcentral_confirm_artifact_action from the configured Home DM to execute this write.",
     });
   }
-  return executePendingAction(createOwnerArtifactClient(cfg), scopedAction);
+  return executePendingAction(createOwnerArtifactClientFromAccount(target.account), scopedAction);
 }
 
 async function confirmArtifactAction(params: {
@@ -642,8 +650,43 @@ function resolveArtifactAccount(cfg: unknown) {
   return resolveAccount(getRcConfig(cfg ?? {}));
 }
 
+function resolveArtifactTarget(cfg: unknown, params: Record<string, unknown>): {
+  account: ResolvedAccount;
+  chatId: string;
+  isAllowlisted: boolean;
+  isHome: boolean;
+} {
+  const account = resolveArtifactAccount(cfg);
+  const chatId = resolveToolChatId(params, account.homeChannel) ?? "";
+  return {
+    account,
+    chatId,
+    isAllowlisted: chatId ? isArtifactChatAllowlisted(account, chatId) : false,
+    isHome: Boolean(chatId && account.homeChannel && chatId === account.homeChannel),
+  };
+}
+
+function isArtifactChatAllowlisted(account: ResolvedAccount, chatId: string): boolean {
+  return account.config.teams?.[chatId]?.allow === true || account.groupDmChannels[chatId]?.allow === true;
+}
+
+async function runBotArtifactAction(
+  account: ResolvedAccount,
+  fn: (client: RingCentralClient) => Promise<AgentToolResult<unknown>>,
+): Promise<AgentToolResult<unknown>> {
+  try {
+    return await fn(createBotClient(account.server, account.botToken));
+  } catch (err) {
+    return errorResult(`RingCentral bot token artifact operation failed: ${formatError(err)}`);
+  }
+}
+
 function createOwnerArtifactClient(cfg: unknown): RingCentralClient {
   const account = resolveArtifactAccount(cfg);
+  return createOwnerArtifactClientFromAccount(account);
+}
+
+function createOwnerArtifactClientFromAccount(account: ResolvedAccount): RingCentralClient {
   if (!hasOwnerCredentials(account)) {
     throw new Error("RingCentral owner credentials are not configured.");
   }
@@ -653,6 +696,10 @@ function createOwnerArtifactClient(cfg: unknown): RingCentralClient {
     account.ownerCredentials!.clientSecret,
     account.ownerCredentials!.jwt,
   );
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function resolveToolChatId(params: Record<string, unknown>, fallback?: string): string | undefined {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,3 +19,7 @@ export function getRingCentralRuntime(): PluginRuntime {
 export function tryGetRingCentralRuntime(): PluginRuntime | null {
   return _runtime;
 }
+
+export function __setRingCentralRuntimeForTest(runtime: PluginRuntime | null): void {
+  _runtime = runtime;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,5 +4,5 @@ export const ringcentralSetupWizard = {
   id: "ringcentral",
   label: "RingCentral",
   description:
-    "Configure RingCentral Team Messaging with RC_BOT_TOKEN and optional RC_USER_* owner credentials.",
+    "Configure RingCentral Team Messaging with a bot token, optional owner credentials, and explicit Team/Group allowlists.",
 };


### PR DESCRIPTION
## Summary
- Allows RingCentral artifact tools to use the bot token directly when the target chat is explicitly allowlisted.
- Keeps the existing owner-backed HomeChannel and confirmation behavior for non-allowlisted targets.
- Documents the simplified allowlist rule and adds regression coverage for bot-only artifact paths.

Fixes #184

## Behavior
- Artifact tools now resolve `chat_id` first, falling back to `homeChannel` / `RC_HOME_CHANNEL` when omitted.
- Explicit allowlist entries enable the bot-token path:
  - `teams.<chatId>.allow === true`
  - `dm.groupChannels.<chatId>.allow === true`
- `teams."*"` and `groupPolicy="open"` do not authorize artifact bot-token access.
- Bot-token failures return directly and do not fall back to owner credentials.
- Non-allowlisted Home targets retain owner-backed direct behavior.
- Non-allowlisted non-Home owner writes continue to require `ringcentral_confirm_artifact_action` from the configured Home DM.

## Tools Covered
- Adaptive Cards: create/get/update/delete
- Notes: list/create/get/update/delete/publish
- Calendar Events: list/create/get/update/delete

For object-ID tools, `chat_id` is used as the authorization context; the RingCentral API still operates on the object ID.

## Validation
- `pnpm test "src/artifact-tools.test.ts" --run`
- `node -e JSON.parse(...)`
- `pnpm typecheck`
- `pnpm test` (`230 passed | 1 skipped`)
- `pnpm build`
- `git diff --check`
